### PR TITLE
Add automated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - feat
+        - feature
+    - title: Fixes
+      labels:
+        - fix
+        - bug
+    - title: Documentation
+      labels:
+        - docs
+        - documentation
+    - title: Maintenance
+      labels:
+        - ci
+        - chore
+        - maintenance
+  exclude:
+    labels:
+      - skip-changelog

--- a/.github/workflows/publish-addon.yml
+++ b/.github/workflows/publish-addon.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -153,3 +153,20 @@ jobs:
             --tag "${latest_image}" \
             "${amd64_image}" \
             "${arm64_image}"
+
+  publish-release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    needs: publish-manifest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The repository includes `.github/workflows/publish-addon.yml`, which publishes o
 - `ghcr.io/hannes-beckmann/luma-weaver-addon:latest`
 
 Home Assistant and standalone Docker both use the same image name, and Docker selects the right `amd64` or `aarch64` variant automatically from the manifest list.
+The same tag also creates a GitHub Release with automatically generated release notes.
 
 ## Development
 


### PR DESCRIPTION
This PR adds automated GitHub Release notes for tagged releases.

- Adds .github/release.yml so GitHub can group release notes by labels like feat, fix, docs, and ci.
- Updates the publish workflow to create a GitHub Release automatically when a tag is pushed.