### PR TITLE
Improve CI and Docker build cache reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Restore cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-stable
 
       - name: Run Rust tests
         run: cargo test -p shared -p backend --locked
@@ -77,6 +79,8 @@ jobs:
 
       - name: Restore cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-stable
 
       - name: Install trunk
         uses: taiki-e/install-action@trunk
@@ -99,7 +103,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Restore Docker cache mounts
+        uses: actions/cache@v4
+        with:
+          path: .buildkit-cache/amd64
+          key: ${{ runner.os }}-buildkit-mounts-amd64-${{ hashFiles('Dockerfile', 'Cargo.lock', 'Cargo.toml', 'crates/backend/Cargo.toml', 'crates/frontend/Cargo.toml', 'crates/shared/Cargo.toml', 'rust-toolchain.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-mounts-amd64-
+
+      - name: Inject Docker cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: .buildkit-cache/amd64
+          dockerfile: Dockerfile
 
       - name: Build amd64 image without pushing
         uses: docker/build-push-action@v6
@@ -109,8 +129,8 @@ jobs:
           load: false
           push: false
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
           build-args: |
             BUILD_ARCH=amd64
             BUILD_FROM=ghcr.io/home-assistant/amd64-base-debian:bookworm

--- a/.github/workflows/publish-addon.yml
+++ b/.github/workflows/publish-addon.yml
@@ -67,7 +67,23 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Restore Docker cache mounts
+        uses: actions/cache@v4
+        with:
+          path: .buildkit-cache/${{ matrix.arch }}
+          key: ${{ runner.os }}-buildkit-mounts-${{ matrix.arch }}-${{ hashFiles('Dockerfile', 'Cargo.lock', 'Cargo.toml', 'crates/backend/Cargo.toml', 'crates/frontend/Cargo.toml', 'crates/shared/Cargo.toml', 'rust-toolchain.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-mounts-${{ matrix.arch }}-
+
+      - name: Inject Docker cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: .buildkit-cache/${{ matrix.arch }}
+          dockerfile: Dockerfile
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -44,7 +44,23 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Restore Docker cache mounts
+        uses: actions/cache@v4
+        with:
+          path: .buildkit-cache/${{ matrix.arch }}
+          key: ${{ runner.os }}-buildkit-mounts-${{ matrix.arch }}-${{ hashFiles('Dockerfile', 'Cargo.lock', 'Cargo.toml', 'crates/backend/Cargo.toml', 'crates/frontend/Cargo.toml', 'crates/shared/Cargo.toml', 'rust-toolchain.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-mounts-${{ matrix.arch }}-
+
+      - name: Inject Docker cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: .buildkit-cache/${{ matrix.arch }}
+          dockerfile: Dockerfile
 
       - name: Build release image without pushing
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,47 @@ ARG BUILD_FROM=debian:bookworm-slim
 ARG BUILD_ARCH=amd64
 ARG BUILD_VERSION=dev
 
-FROM rust:bookworm AS builder
+FROM rust:bookworm AS chef-base
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         binaryen \
         build-essential \
+        binutils \
         ca-certificates \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup target add wasm32-unknown-unknown \
-    && cargo install --locked trunk \
-    && cargo install --locked wasm-bindgen-cli
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/tmp/cargo-target \
+    rustup target add wasm32-unknown-unknown \
+    && CARGO_TARGET_DIR=/tmp/cargo-target cargo install --locked cargo-chef \
+    && CARGO_TARGET_DIR=/tmp/cargo-target cargo install --locked trunk \
+    && CARGO_TARGET_DIR=/tmp/cargo-target cargo install --locked wasm-bindgen-cli
 
 WORKDIR /app
 
+FROM chef-base AS planner
+
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/backend/Cargo.toml crates/backend/Cargo.toml
+COPY crates/frontend/Cargo.toml crates/frontend/Cargo.toml
+COPY crates/shared/Cargo.toml crates/shared/Cargo.toml
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef-base AS builder
+
+WORKDIR /app
+
+COPY --from=planner /app/recipe.json /app/recipe.json
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo chef cook --release --recipe-path recipe.json
+
 COPY crates ./crates
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -32,7 +56,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     cd /app/crates/frontend \
     && trunk build --release \
-    && install -D /app/target/release/backend /out/backend
+    && install -D /app/target/release/backend /out/backend \
+    && strip /out/backend
 
 FROM ${BUILD_FROM} AS runtime
 
@@ -48,7 +73,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         bash \
         ca-certificates \
-        wget \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- share the Rust dependency cache between the CI test and frontend jobs
- align the Docker smoke build with the `amd64` BuildKit cache scope used by release workflows
- persist Docker BuildKit cache mounts so Cargo registry, git, and target caches survive across workflow runs

## Why
These workflow updates are aimed at keeping repeat GitHub Actions runs fast after the first successful pass, especially for Rust and Docker-heavy paths.

## Testing
- not run locally
- verified workflow changes statically in-repo