### PR TITLE
ci: declare explicit cargo targets for cargo-chef planning

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[[bin]]
+name = "backend"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary
- declare the backend binary target explicitly in its manifest
- declare the shared library target explicitly in its manifest
- unblock `cargo chef prepare` in the Docker planner stage when only manifests are copied

## Why
The planner stage copies workspace manifests without source files. `cargo metadata` could not infer targets for crates that relied on default `src/main.rs` or `src/lib.rs` discovery, which caused the Docker build to fail before dependency planning.

## Testing
- not run locally
- validated against the reported Docker planner error and current workspace manifests