### PR TITLE
ci: limit default workspace members for docker cargo-chef builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["crates/backend", "crates/frontend", "crates/shared"]
+default-members = ["crates/backend", "crates/shared"]
 resolver = "3"
 
 [workspace.package]


### PR DESCRIPTION
## Summary
- set workspace `default-members` to backend and shared
- keep the frontend crate in the workspace while excluding it from default host-side cargo commands
- unblock Docker `cargo chef cook` from pulling the wasm-oriented frontend into the native dependency build

## Why
The Docker builder runs `cargo chef cook --release --recipe-path recipe.json` without explicit package selection. That caused Cargo to include the frontend crate in the native Linux dependency build, which then failed in `winit` before the later `trunk build` step could compile the frontend for `wasm32`.

## Testing
- not run locally
- validated against the reported Docker build failure and current workspace layout