### PR TITLE
feat(nodes): add moving median temporal filter

### DIFF
--- a/crates/backend/src/node_runtime/nodes/temporal_filters/mod.rs
+++ b/crates/backend/src/node_runtime/nodes/temporal_filters/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod delay;
 pub(crate) mod fade;
 pub(crate) mod moving_average;
+pub(crate) mod moving_median;

--- a/crates/backend/src/node_runtime/nodes/temporal_filters/moving_median.rs
+++ b/crates/backend/src/node_runtime/nodes/temporal_filters/moving_median.rs
@@ -1,0 +1,288 @@
+use std::collections::VecDeque;
+
+use anyhow::Result;
+use shared::{FloatTensor, InputValue};
+
+use crate::node_runtime::{
+    AnyInputValue, NodeEvaluationContext, RuntimeNode, RuntimeNodeFromParameters, RuntimeOutputs,
+    TypedNodeEvaluation,
+};
+
+#[derive(Default)]
+pub(crate) struct MovingMedianNode {
+    history: VecDeque<MedianSample>,
+}
+
+impl RuntimeNodeFromParameters for MovingMedianNode {}
+
+pub(crate) struct MovingMedianInputs {
+    value: AnyInputValue,
+    window_size: f32,
+}
+
+crate::node_runtime::impl_runtime_inputs!(MovingMedianInputs {
+    value = AnyInputValue(InputValue::Float(0.0)),
+    window_size = 4.0,
+});
+
+pub(crate) struct MovingMedianOutputs {
+    value: InputValue,
+}
+
+impl RuntimeOutputs for MovingMedianOutputs {
+    fn into_runtime_outputs(self) -> anyhow::Result<std::collections::HashMap<String, InputValue>> {
+        let mut outputs = std::collections::HashMap::new();
+        outputs.insert("value".to_owned(), self.value);
+        Ok(outputs)
+    }
+}
+
+impl RuntimeNode for MovingMedianNode {
+    type Inputs = MovingMedianInputs;
+    type Outputs = MovingMedianOutputs;
+
+    fn evaluate(
+        &mut self,
+        _context: &NodeEvaluationContext,
+        inputs: Self::Inputs,
+    ) -> Result<TypedNodeEvaluation<Self::Outputs>> {
+        let value = inputs.value.0;
+        let window_size = inputs.window_size.round().clamp(1.0, 240.0) as usize;
+
+        let Some(sample) = MedianSample::from_input_value(&value) else {
+            return Ok(TypedNodeEvaluation::from_outputs(MovingMedianOutputs { value }));
+        };
+
+        if self
+            .history
+            .front()
+            .is_some_and(|existing| !existing.is_compatible(&sample))
+        {
+            self.history.clear();
+        }
+
+        self.history.push_back(sample);
+        while self.history.len() > window_size {
+            self.history.pop_front();
+        }
+
+        let median = self
+            .history
+            .front()
+            .map(|sample| sample.median(&self.history))
+            .unwrap_or(value);
+
+        Ok(TypedNodeEvaluation::from_outputs(MovingMedianOutputs {
+            value: median,
+        }))
+    }
+}
+
+#[derive(Clone)]
+enum MedianSample {
+    Float(f32),
+    Tensor(FloatTensor),
+}
+
+impl MedianSample {
+    fn from_input_value(value: &InputValue) -> Option<Self> {
+        match value {
+            InputValue::Float(number) => Some(Self::Float(*number)),
+            InputValue::FloatTensor(tensor) => Some(Self::Tensor(tensor.clone())),
+            _ => None,
+        }
+    }
+
+    fn is_compatible(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Float(_), Self::Float(_)) => true,
+            (Self::Tensor(left), Self::Tensor(right)) => {
+                left.shape == right.shape && left.values.len() == right.values.len()
+            }
+            _ => false,
+        }
+    }
+
+    fn median(&self, history: &VecDeque<Self>) -> InputValue {
+        match self {
+            Self::Float(_) => InputValue::Float(median_scalar(
+                &history
+                    .iter()
+                    .filter_map(|sample| match sample {
+                        Self::Float(value) => Some(*value),
+                        Self::Tensor(_) => None,
+                    })
+                    .collect::<Vec<_>>(),
+            )),
+            Self::Tensor(tensor) => {
+                let mut medians = vec![0.0; tensor.values.len()];
+                for (index, median) in medians.iter_mut().enumerate() {
+                    let values = history
+                        .iter()
+                        .filter_map(|sample| match sample {
+                            Self::Tensor(sample_tensor) => sample_tensor.values.get(index).copied(),
+                            Self::Float(_) => None,
+                        })
+                        .collect::<Vec<_>>();
+                    *median = median_scalar(&values);
+                }
+
+                InputValue::FloatTensor(FloatTensor {
+                    shape: tensor.shape.clone(),
+                    values: medians,
+                })
+            }
+        }
+    }
+}
+
+fn median_scalar(values: &[f32]) -> f32 {
+    if values.is_empty() {
+        return 0.0;
+    }
+
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|left, right| left.total_cmp(right));
+    let middle = sorted.len() / 2;
+    if sorted.len() % 2 == 1 {
+        sorted[middle]
+    } else {
+        (sorted[middle - 1] + sorted[middle]) * 0.5
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context() -> NodeEvaluationContext {
+        NodeEvaluationContext {
+            graph_id: "test-graph".to_owned(),
+            graph_name: "Test Graph".to_owned(),
+            elapsed_seconds: 0.0,
+            render_layout: None,
+        }
+    }
+
+    #[test]
+    fn filters_float_outliers() {
+        let mut node = MovingMedianNode::default();
+        let samples = [1.0, 1.0, 100.0, 1.0, 1.0];
+        let mut last = InputValue::Float(0.0);
+
+        for sample in samples {
+            last = node
+                .evaluate(
+                    &context(),
+                    MovingMedianInputs {
+                        value: AnyInputValue(InputValue::Float(sample)),
+                        window_size: 5.0,
+                    },
+                )
+                .expect("float median")
+                .outputs
+                .value;
+        }
+
+        assert_eq!(last, InputValue::Float(1.0));
+    }
+
+    #[test]
+    fn averages_middle_pair_for_even_float_windows() {
+        let mut node = MovingMedianNode::default();
+        let mut last = InputValue::Float(0.0);
+
+        for sample in [1.0, 3.0, 5.0, 7.0] {
+            last = node
+                .evaluate(
+                    &context(),
+                    MovingMedianInputs {
+                        value: AnyInputValue(InputValue::Float(sample)),
+                        window_size: 4.0,
+                    },
+                )
+                .expect("even float median")
+                .outputs
+                .value;
+        }
+
+        assert_eq!(last, InputValue::Float(4.0));
+    }
+
+    #[test]
+    fn filters_tensor_outliers_per_index() {
+        let mut node = MovingMedianNode::default();
+        let samples = [
+            vec![1.0, 10.0],
+            vec![2.0, 11.0],
+            vec![100.0, -50.0],
+            vec![3.0, 12.0],
+            vec![4.0, 13.0],
+        ];
+        let mut last = InputValue::Float(0.0);
+
+        for values in samples {
+            last = node
+                .evaluate(
+                    &context(),
+                    MovingMedianInputs {
+                        value: AnyInputValue(InputValue::FloatTensor(FloatTensor {
+                            shape: vec![2],
+                            values,
+                        })),
+                        window_size: 5.0,
+                    },
+                )
+                .expect("tensor median")
+                .outputs
+                .value;
+        }
+
+        assert_eq!(
+            last,
+            InputValue::FloatTensor(FloatTensor {
+                shape: vec![2],
+                values: vec![3.0, 11.0],
+            })
+        );
+    }
+
+    #[test]
+    fn resets_history_when_tensor_shape_changes() {
+        let mut node = MovingMedianNode::default();
+
+        let _ = node
+            .evaluate(
+                &context(),
+                MovingMedianInputs {
+                    value: AnyInputValue(InputValue::FloatTensor(FloatTensor {
+                        shape: vec![2],
+                        values: vec![1.0, 3.0],
+                    })),
+                    window_size: 4.0,
+                },
+            )
+            .expect("first tensor median");
+
+        let output = node
+            .evaluate(
+                &context(),
+                MovingMedianInputs {
+                    value: AnyInputValue(InputValue::FloatTensor(FloatTensor {
+                        shape: vec![3],
+                        values: vec![8.0, 6.0, 4.0],
+                    })),
+                    window_size: 4.0,
+                },
+            )
+            .expect("reset tensor median");
+
+        assert_eq!(
+            output.outputs.value,
+            InputValue::FloatTensor(FloatTensor {
+                shape: vec![3],
+                values: vec![8.0, 6.0, 4.0],
+            })
+        );
+    }
+}

--- a/crates/backend/src/node_runtime/registry.rs
+++ b/crates/backend/src/node_runtime/registry.rs
@@ -218,6 +218,10 @@ pub(crate) fn build_builtin_node_registry() -> anyhow::Result<Arc<NodeRegistry>>
         nodes::temporal_filters::moving_average::MovingAverageNode
     );
     register_builtin!(
+        NodeTypeId::MOVING_MEDIAN,
+        nodes::temporal_filters::moving_median::MovingMedianNode
+    );
+    register_builtin!(
         NodeTypeId::BOX_BLUR,
         nodes::spatial_filters::box_blur::BoxBlurNode
     );

--- a/crates/shared/src/graph/builtin_nodes.rs
+++ b/crates/shared/src/graph/builtin_nodes.rs
@@ -917,6 +917,40 @@ static MOVING_AVERAGE_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| Nod
     runtime_updates: None,
 });
 
+static MOVING_MEDIAN_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
+    id: NodeTypeId::MOVING_MEDIAN.to_owned(),
+    display_name: "Moving Median".to_owned(),
+    category: NodeCategory::TemporalFilters,
+    inputs: vec![
+        NodeInputDefinition {
+            name: "value".to_owned(),
+            display_name: title_case_name("value"),
+            value_kind: ValueKind::Any,
+            accepted_kinds: vec![ValueKind::Float, ValueKind::FloatTensor],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+        NodeInputDefinition {
+            name: "window_size".to_owned(),
+            display_name: title_case_name("window_size"),
+            value_kind: ValueKind::Float,
+            accepted_kinds: vec![],
+            default_value: Some(InputValue::Float(4.0)),
+        },
+    ],
+    outputs: vec![NodeOutputDefinition {
+        name: "value".to_owned(),
+        display_name: title_case_name("value"),
+        value_kind: ValueKind::Any,
+        accepted_kinds: vec![ValueKind::Float, ValueKind::FloatTensor],
+    }],
+    parameters: vec![],
+    connection: NodeConnectionDefinition {
+        max_input_connections: 1,
+        require_value_kind_match: true,
+    },
+    runtime_updates: None,
+});
+
 static BOX_BLUR_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
     id: NodeTypeId::BOX_BLUR.to_owned(),
     display_name: "Box Blur".to_owned(),
@@ -1526,6 +1560,7 @@ pub fn builtin_node_definitions() -> Vec<NodeDefinition> {
         (*ALPHA_OVER_NODE_TYPE).clone(),
         (*FADE_NODE_TYPE).clone(),
         (*MOVING_AVERAGE_NODE_TYPE).clone(),
+        (*MOVING_MEDIAN_NODE_TYPE).clone(),
         (*BOX_BLUR_NODE_TYPE).clone(),
         (*GAUSSIAN_BLUR_NODE_TYPE).clone(),
         (*MEDIAN_FILTER_NODE_TYPE).clone(),

--- a/crates/shared/src/graph/node_definition.rs
+++ b/crates/shared/src/graph/node_definition.rs
@@ -35,6 +35,7 @@ impl NodeTypeId {
     pub const ALPHA_OVER: &'static str = "frame_operations.alpha_over";
     pub const FADE: &'static str = "temporal_filters.fade";
     pub const MOVING_AVERAGE: &'static str = "temporal_filters.moving_average";
+    pub const MOVING_MEDIAN: &'static str = "temporal_filters.moving_median";
     pub const BOX_BLUR: &'static str = "spatial_filters.box_blur";
     pub const GAUSSIAN_BLUR: &'static str = "spatial_filters.gaussian_blur";
     pub const MEDIAN_FILTER: &'static str = "spatial_filters.median_filter";


### PR DESCRIPTION
## Summary
- add a new built-in `Moving Median` temporal filter node
- register the backend runtime and shared node definition so it appears in the existing node catalog
- support float and float-tensor inputs with median filtering over a configurable `window_size`

## Why
- moving median filtering rejects one-off spikes and outliers better than moving average smoothing
- this implements the dedicated temporal filter requested in issue #16

## Testing
- `cargo test -p backend moving_median --locked`

## Compatibility Notes
- adds a new built-in node without changing existing node ids or persisted graph behavior

Closes #16