### PR TITLE
fix(frontend): restore GitHub Pages deep links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo chef cook --release --recipe-path recipe.json
 
 COPY crates ./crates
+COPY examples ./examples
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \

--- a/crates/frontend/404.html
+++ b/crates/frontend/404.html
@@ -6,8 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
-    <link data-trunk rel="icon" type="image/svg+xml" href="icon.svg" />
-    <link data-trunk rel="copy-file" href="404.html" />
+    <link rel="icon" type="image/svg+xml" href="icon.svg" />
     <title>Luma Weaver</title>
     <style>
       html,
@@ -25,4 +24,3 @@
     <canvas id="app-canvas"></canvas>
   </body>
 </html>
-

--- a/crates/frontend/src/app/navigation.rs
+++ b/crates/frontend/src/app/navigation.rs
@@ -56,8 +56,9 @@ impl FrontendApp {
         let Ok(pathname) = window.location().pathname() else {
             return;
         };
+        let base_path = app_base_path();
 
-        if let Some(graph_id) = graph_id_from_path(&pathname) {
+        if let Some(graph_id) = graph_id_from_path_with_base(&pathname, &base_path) {
             self.ui.selected_graph_id = Some(graph_id);
             self.ui.active_view = AppView::Editor;
         }
@@ -81,8 +82,9 @@ impl FrontendApp {
         let Ok(pathname) = window.location().pathname() else {
             return;
         };
+        let base_path = app_base_path();
 
-        match graph_id_from_path(&pathname) {
+        match graph_id_from_path_with_base(&pathname, &base_path) {
             Some(graph_id) => {
                 let already_selected = self.ui.active_view == AppView::Editor
                     && self.ui.selected_graph_id.as_deref() == Some(graph_id.as_str());
@@ -118,16 +120,7 @@ impl FrontendApp {
         let Ok(history) = window.history() else {
             return;
         };
-
-        let path = match self.ui.active_view {
-            AppView::Dashboard => "/".to_owned(),
-            AppView::Editor => self
-                .ui
-                .selected_graph_id
-                .as_deref()
-                .map(|graph_id| format!("/graphs/{graph_id}"))
-                .unwrap_or_else(|| "/".to_owned()),
-        };
+        let path = route_path_for_view(self);
 
         let _ = history.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&path));
     }
@@ -150,16 +143,7 @@ impl FrontendApp {
         let Ok(history) = window.history() else {
             return;
         };
-
-        let path = match self.ui.active_view {
-            AppView::Dashboard => "/".to_owned(),
-            AppView::Editor => self
-                .ui
-                .selected_graph_id
-                .as_deref()
-                .map(|graph_id| format!("/graphs/{graph_id}"))
-                .unwrap_or_else(|| "/".to_owned()),
-        };
+        let path = route_path_for_view(self);
 
         let _ = history.push_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&path));
     }
@@ -282,6 +266,11 @@ impl FrontendApp {
 ///
 /// The current route format is `/graphs/<graph_id>`.
 fn graph_id_from_path(pathname: &str) -> Option<String> {
+    graph_id_from_path_with_base(pathname, "")
+}
+
+fn graph_id_from_path_with_base(pathname: &str, base_path: &str) -> Option<String> {
+    let pathname = strip_base_path(pathname, base_path)?;
     let mut segments = pathname.trim_matches('/').split('/');
     match (segments.next(), segments.next(), segments.next()) {
         (Some("graphs"), Some(graph_id), None) if !graph_id.is_empty() => Some(graph_id.to_owned()),
@@ -289,9 +278,77 @@ fn graph_id_from_path(pathname: &str) -> Option<String> {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+fn route_path_for_view(app: &FrontendApp) -> String {
+    let relative_path = match app.ui.active_view {
+        AppView::Dashboard => "/".to_owned(),
+        AppView::Editor => app
+            .ui
+            .selected_graph_id
+            .as_deref()
+            .map(|graph_id| format!("/graphs/{graph_id}"))
+            .unwrap_or_else(|| "/".to_owned()),
+    };
+    join_base_path(&app_base_path(), &relative_path)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn app_base_path() -> String {
+    let Some(window) = web_sys::window() else {
+        return String::new();
+    };
+    let Some(document) = window.document() else {
+        return String::new();
+    };
+    let Some(base_uri) = document.base_uri().ok().flatten() else {
+        return String::new();
+    };
+    let Ok(url) = web_sys::Url::new(&base_uri) else {
+        return String::new();
+    };
+    normalize_base_path(&url.pathname())
+}
+
+fn strip_base_path<'a>(pathname: &'a str, base_path: &str) -> Option<&'a str> {
+    if base_path.is_empty() {
+        return Some(pathname);
+    }
+
+    if pathname == base_path {
+        return Some("/");
+    }
+
+    pathname
+        .strip_prefix(base_path)
+        .filter(|suffix| suffix.starts_with('/'))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn join_base_path(base_path: &str, relative_path: &str) -> String {
+    if base_path.is_empty() {
+        return relative_path.to_owned();
+    }
+
+    if relative_path == "/" {
+        format!("{base_path}/")
+    } else {
+        format!("{base_path}{relative_path}")
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn normalize_base_path(pathname: &str) -> String {
+    let trimmed = pathname.trim_end_matches('/');
+    if trimmed.is_empty() || trimmed == "/" {
+        String::new()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::graph_id_from_path;
+    use super::{graph_id_from_path, graph_id_from_path_with_base};
 
     #[test]
     fn parses_graph_route() {
@@ -304,5 +361,17 @@ mod tests {
         assert_eq!(graph_id_from_path("/"), None);
         assert_eq!(graph_id_from_path("/graphs"), None);
         assert_eq!(graph_id_from_path("/graphs/demo/extra"), None);
+    }
+
+    #[test]
+    fn parses_graph_route_under_base_path() {
+        assert_eq!(
+            graph_id_from_path_with_base("/luma-weaver/graphs/demo", "/luma-weaver"),
+            Some("demo".to_owned())
+        );
+        assert_eq!(
+            graph_id_from_path_with_base("/luma-weaver/", "/luma-weaver"),
+            None
+        );
     }
 }

--- a/crates/frontend/src/app/navigation.rs
+++ b/crates/frontend/src/app/navigation.rs
@@ -297,16 +297,10 @@ fn app_base_path() -> String {
     let Some(window) = web_sys::window() else {
         return String::new();
     };
-    let Some(document) = window.document() else {
+    let Ok(pathname) = window.location().pathname() else {
         return String::new();
     };
-    let Some(base_uri) = document.base_uri().ok().flatten() else {
-        return String::new();
-    };
-    let Ok(url) = web_sys::Url::new(&base_uri) else {
-        return String::new();
-    };
-    normalize_base_path(&url.pathname())
+    infer_base_path_from_location(&pathname)
 }
 
 fn strip_base_path<'a>(pathname: &'a str, base_path: &str) -> Option<&'a str> {
@@ -336,7 +330,6 @@ fn join_base_path(base_path: &str, relative_path: &str) -> String {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
 fn normalize_base_path(pathname: &str) -> String {
     let trimmed = pathname.trim_end_matches('/');
     if trimmed.is_empty() || trimmed == "/" {
@@ -346,9 +339,22 @@ fn normalize_base_path(pathname: &str) -> String {
     }
 }
 
+fn infer_base_path_from_location(pathname: &str) -> String {
+    let trimmed = pathname.trim_end_matches('/');
+    if trimmed.is_empty() || trimmed == "/" {
+        return String::new();
+    }
+
+    if let Some((base_path, _)) = trimmed.split_once("/graphs/") {
+        normalize_base_path(base_path)
+    } else {
+        normalize_base_path(trimmed)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{graph_id_from_path, graph_id_from_path_with_base};
+    use super::{graph_id_from_path, graph_id_from_path_with_base, infer_base_path_from_location};
 
     #[test]
     fn parses_graph_route() {
@@ -372,6 +378,19 @@ mod tests {
         assert_eq!(
             graph_id_from_path_with_base("/luma-weaver/", "/luma-weaver"),
             None
+        );
+    }
+
+    #[test]
+    fn infers_pages_base_path_from_dashboard_and_graph_routes() {
+        assert_eq!(infer_base_path_from_location("/"), String::new());
+        assert_eq!(
+            infer_base_path_from_location("/luma-weaver/"),
+            "/luma-weaver".to_owned()
+        );
+        assert_eq!(
+            infer_base_path_from_location("/luma-weaver/graphs/demo"),
+            "/luma-weaver".to_owned()
         );
     }
 }


### PR DESCRIPTION
## Summary
- restore GitHub Pages deep-link handling for the demo frontend
- keep the Pages base path stable when navigating between dashboard and graph routes
- include the seeded example graph in the Docker builder context so demo-mode backend compilation succeeds in CI

## Why
The Pages demo needed a proper SPA fallback and base-path-aware routing so reloads on `/luma-weaver/graphs/<id>` work correctly. A follow-up regression caused the in-app `Open` action to stop working after landing on a graph route because the app started treating the full graph path as its base URL.

CI also started failing in the Docker smoke build because `crates/backend/src/demo.rs` now embeds `examples/Example.animation-graph.json` with `include_str!`, but the Docker builder image was only copying `crates/` before compiling `backend`.

## Impact
- deep links on GitHub Pages reload into the app instead of 404ing
- opening graphs from the dashboard works again after the Pages routing fix
- the Docker smoke build has access to the seeded example graph during backend compilation

## Testing
- `cargo test -p frontend --locked`
- `trunk build --release --features demo-mode --public-url /luma-weaver/`
- `cargo build --locked --release -p backend`

## Compatibility Notes
This changes browser routing behavior for the GitHub Pages demo only. It does not change persisted graph format or backend API contracts.