### PR TITLE
fix(ci): split rustdoc builds by target

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -70,9 +70,13 @@ jobs:
         env:
           MDBOOK_OUTPUT__HTML__SITE_URL: ${{ steps.pages-paths.outputs.docs_site_url }}
 
-      - name: Build Rust reference docs
+      - name: Build Rust reference docs for backend and shared
         shell: bash
-        run: cargo doc --workspace --no-deps
+        run: cargo doc -p backend -p shared --no-deps --locked
+
+      - name: Build Rust reference docs for frontend wasm target
+        shell: bash
+        run: cargo doc -p frontend --no-deps --locked --target wasm32-unknown-unknown
 
       - name: Assemble GitHub Pages artifact
         shell: bash
@@ -82,6 +86,8 @@ jobs:
           cp -R crates/frontend/dist/. site/
           cp -R docs-book/book/. site/docs/
           cp -R target/doc/. site/reference/
+          cp -R target/wasm32-unknown-unknown/doc/frontend site/reference/frontend
+          cp -R target/wasm32-unknown-unknown/doc/src site/reference/src
           touch site/.nojekyll
 
       - name: Upload GitHub Pages artifact

--- a/docs/developer/workflows.md
+++ b/docs/developer/workflows.md
@@ -66,7 +66,8 @@ This workflow:
 - runs manually with `workflow_dispatch`
 - builds `crates/frontend` with `--features demo-mode`
 - builds the docs site with `mdbook`
-- builds generated Rust reference docs with `cargo doc --workspace --no-deps`
+- builds generated Rust reference docs for `backend` and `shared` natively
+- builds generated Rust reference docs for `frontend` on `wasm32-unknown-unknown`
 - assembles one GitHub Pages artifact containing the preview app, docs, and reference
 
 Published paths:
@@ -87,7 +88,8 @@ Common commands:
 - `trunk build --release`
 - `trunk build --release --features demo-mode --public-url /luma-weaver/`
 - `mdbook build docs-book`
-- `cargo doc --workspace --no-deps`
+- `cargo doc -p backend -p shared --no-deps --locked`
+- `cargo doc -p frontend --no-deps --locked --target wasm32-unknown-unknown`
 
 ## Branch And PR Conventions
 


### PR DESCRIPTION
## Summary
- split the Pages rustdoc build by target
- build `backend` and `shared` natively
- build `frontend` for `wasm32-unknown-unknown`
- keep the combined reference output under `/reference/`

## Why
- the Pages workflow currently tries to run `cargo doc --workspace --no-deps` natively on Ubuntu
- that pulls in the `frontend` crate through native `eframe`/`winit` code paths
- the native Linux rustdoc build fails because this repo does not enable a Linux `winit` backend for the frontend crate

## Testing
- `cargo doc -p backend -p shared --no-deps --locked`
- `cargo doc -p frontend --no-deps --locked --target wasm32-unknown-unknown`

## Compatibility Notes
- no user-facing docs layout changes
- Pages still publishes the combined reference site under `/luma-weaver/reference/`