### PR TITLE
feat(outputs): add disable inputs to WLED nodes

### DIFF
--- a/crates/backend/src/node_runtime/nodes/debug/wled_dummy_display.rs
+++ b/crates/backend/src/node_runtime/nodes/debug/wled_dummy_display.rs
@@ -18,10 +18,12 @@ crate::node_runtime::impl_runtime_parameters!(WledDummyDisplayNode {
 
 pub(crate) struct WledDummyDisplayInputs {
     value: Option<AnyInputValue>,
+    disable: f32,
 }
 
 crate::node_runtime::impl_runtime_inputs!(WledDummyDisplayInputs {
     value = None,
+    disable = 0.0,
 });
 
 impl RuntimeNode for WledDummyDisplayNode {
@@ -41,24 +43,17 @@ impl RuntimeNode for WledDummyDisplayNode {
             height: Some(self.height),
         });
 
-        let frame = match inputs.value.map(|value| value.0) {
-            Some(InputValue::ColorFrame(frame)) => normalize_frame(frame, &layout),
-            Some(InputValue::Color(color)) => ColorFrame {
-                layout: layout.clone(),
-                pixels: vec![color; layout.pixel_count],
-            },
-            _ => ColorFrame {
-                layout: layout.clone(),
-                pixels: vec![
-                    RgbaColor {
-                        r: 0.0,
-                        g: 0.0,
-                        b: 0.0,
-                        a: 1.0,
-                    };
-                    layout.pixel_count
-                ],
-            },
+        let frame = if is_disabled(inputs.disable) {
+            black_frame(&layout)
+        } else {
+            match inputs.value.map(|value| value.0) {
+                Some(InputValue::ColorFrame(frame)) => normalize_frame(frame, &layout),
+                Some(InputValue::Color(color)) => ColorFrame {
+                    layout: layout.clone(),
+                    pixels: vec![color; layout.pixel_count],
+                },
+                _ => black_frame(&layout),
+            }
         };
 
         Ok(TypedNodeEvaluation::with_frontend_updates(
@@ -68,6 +63,25 @@ impl RuntimeNode for WledDummyDisplayNode {
                 value: InputValue::ColorFrame(frame),
             }],
         ))
+    }
+}
+
+fn is_disabled(value: f32) -> bool {
+    value >= 0.5
+}
+
+fn black_frame(layout: &LedLayout) -> ColorFrame {
+    ColorFrame {
+        layout: layout.clone(),
+        pixels: vec![
+            RgbaColor {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            };
+            layout.pixel_count
+        ],
     }
 }
 
@@ -87,4 +101,68 @@ fn normalize_frame(mut frame: ColorFrame, layout: &LedLayout) -> ColorFrame {
         ));
     }
     frame
+}
+
+#[cfg(test)]
+mod tests {
+    use shared::{InputValue, RgbaColor};
+
+    use super::{WledDummyDisplayInputs, WledDummyDisplayNode, is_disabled};
+    use crate::node_runtime::{AnyInputValue, NodeEvaluationContext, RuntimeNode};
+
+    fn evaluation_context() -> NodeEvaluationContext {
+        NodeEvaluationContext {
+            graph_id: "graph".to_owned(),
+            graph_name: "Graph".to_owned(),
+            elapsed_seconds: 0.0,
+            render_layout: None,
+        }
+    }
+
+    #[test]
+    fn disable_threshold_matches_issue_contract() {
+        assert!(!is_disabled(0.49));
+        assert!(is_disabled(0.5));
+        assert!(is_disabled(1.0));
+    }
+
+    #[test]
+    fn disabled_dummy_display_emits_black_frame_update() {
+        let mut node = WledDummyDisplayNode {
+            width: 8,
+            height: 8,
+        };
+        let evaluation = node
+            .evaluate(
+                &evaluation_context(),
+                WledDummyDisplayInputs {
+                    value: Some(AnyInputValue(InputValue::Color(RgbaColor {
+                        r: 1.0,
+                        g: 0.2,
+                        b: 0.1,
+                        a: 1.0,
+                    }))),
+                    disable: 1.0,
+                },
+            )
+            .expect("evaluate disabled display");
+
+        let frame = match &evaluation.frontend_updates[0].value {
+            InputValue::ColorFrame(frame) => frame,
+            value => panic!("expected color frame update, got {value:?}"),
+        };
+
+        assert_eq!(frame.layout.width, Some(8));
+        assert_eq!(frame.layout.height, Some(8));
+        assert_eq!(frame.pixels.len(), 64);
+        assert!(frame.pixels.iter().all(|pixel| {
+            *pixel
+                == RgbaColor {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                }
+        }));
+    }
 }

--- a/crates/backend/src/node_runtime/nodes/outputs/wled_target.rs
+++ b/crates/backend/src/node_runtime/nodes/outputs/wled_target.rs
@@ -58,10 +58,12 @@ impl RuntimeNodeFromParameters for WledTargetNode {
 
 pub(crate) struct WledTargetInputs {
     value: Option<AnyInputValue>,
+    disable: f32,
 }
 
 crate::node_runtime::impl_runtime_inputs!(WledTargetInputs {
     value = None,
+    disable = 0.0,
 });
 
 impl RuntimeNode for WledTargetNode {
@@ -75,6 +77,7 @@ impl RuntimeNode for WledTargetNode {
         inputs: Self::Inputs,
     ) -> Result<TypedNodeEvaluation<Self::Outputs>> {
         let mut diagnostics = Vec::new();
+        let disabled = is_disabled(inputs.disable);
         let layout = context.render_layout.clone().unwrap_or(LedLayout {
             id: "wled_target".to_owned(),
             pixel_count: self.led_count,
@@ -104,18 +107,20 @@ impl RuntimeNode for WledTargetNode {
 
         diagnostics.extend(self.refresh_transport_if_needed());
 
-        if let Some(transport) = &mut self.transport {
-            if let Err(error) = transport.send(&frame_for_transport, self.led_count) {
-                tracing::warn!(
-                    target = %self.target,
-                    %error,
-                    "failed to send DDP frame to WLED target"
-                );
-                diagnostics.push(NodeDiagnostic {
-                    severity: NodeDiagnosticSeverity::Error,
-                    code: Some("wled_target_send_failed".to_owned()),
-                    message: format!("Failed to send DDP frame to target {}.", self.target),
-                });
+        if !disabled {
+            if let Some(transport) = &mut self.transport {
+                if let Err(error) = transport.send(&frame_for_transport, self.led_count) {
+                    tracing::warn!(
+                        target = %self.target,
+                        %error,
+                        "failed to send DDP frame to WLED target"
+                    );
+                    diagnostics.push(NodeDiagnostic {
+                        severity: NodeDiagnosticSeverity::Error,
+                        code: Some("wled_target_send_failed".to_owned()),
+                        message: format!("Failed to send DDP frame to target {}.", self.target),
+                    });
+                }
             }
         }
 
@@ -157,6 +162,10 @@ impl WledTargetNode {
         }
         diagnostics
     }
+}
+
+fn is_disabled(value: f32) -> bool {
+    value >= 0.5
 }
 
 struct WledDdpTransport {
@@ -203,12 +212,58 @@ fn resolve_target(target: &str) -> Result<SocketAddr> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_target;
+    use std::collections::HashMap;
+
+    use shared::{InputValue, NodeDiagnosticSeverity};
+
+    use super::{WledTargetInputs, WledTargetNode, is_disabled, resolve_target};
+    use crate::node_runtime::{NodeEvaluationContext, RuntimeInputs, RuntimeNode};
+
+    fn evaluation_context() -> NodeEvaluationContext {
+        NodeEvaluationContext {
+            graph_id: "graph".to_owned(),
+            graph_name: "Graph".to_owned(),
+            elapsed_seconds: 0.0,
+            render_layout: None,
+        }
+    }
 
     /// Tests that bare hostnames inherit the default DDP port during target resolution.
     #[test]
     fn resolve_target_adds_default_ddp_port() {
         let addr = resolve_target("127.0.0.1").expect("resolve target");
         assert_eq!(addr.port(), 4048);
+    }
+
+    #[test]
+    fn disable_threshold_matches_issue_contract() {
+        assert!(!is_disabled(0.49));
+        assert!(is_disabled(0.5));
+        assert!(is_disabled(1.0));
+    }
+
+    #[test]
+    fn disabled_target_still_reports_missing_target_diagnostic() {
+        let mut node = WledTargetNode::default();
+        let mut runtime_inputs = HashMap::new();
+        runtime_inputs.insert("disable".to_owned(), InputValue::Float(1.0));
+        let inputs =
+            WledTargetInputs::from_runtime_inputs(&runtime_inputs).expect("runtime inputs");
+
+        let evaluation = node
+            .evaluate(&evaluation_context(), inputs)
+            .expect("evaluate disabled node");
+
+        assert!(evaluation.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code.as_deref() == Some("wled_target_missing_target")
+                && diagnostic.severity == NodeDiagnosticSeverity::Warning
+        }));
+    }
+
+    #[test]
+    fn disabled_target_skips_invalid_value_types_for_disable_by_using_default() {
+        let inputs =
+            WledTargetInputs::from_runtime_inputs(&HashMap::new()).expect("default inputs");
+        assert!(!is_disabled(inputs.disable));
     }
 }

--- a/crates/shared/src/graph/builtin_nodes.rs
+++ b/crates/shared/src/graph/builtin_nodes.rs
@@ -289,13 +289,22 @@ static WLED_TARGET_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDe
     display_name: "Wled Target".to_owned(),
     category: NodeCategory::Outputs,
     needs_io: true,
-    inputs: vec![NodeInputDefinition {
-        name: "value".to_owned(),
-        display_name: title_case_name("value"),
-        value_kind: ValueKind::ColorFrame,
-        accepted_kinds: vec![ValueKind::Color],
-        default_value: None,
-    }],
+    inputs: vec![
+        NodeInputDefinition {
+            name: "value".to_owned(),
+            display_name: title_case_name("value"),
+            value_kind: ValueKind::ColorFrame,
+            accepted_kinds: vec![ValueKind::Color],
+            default_value: None,
+        },
+        NodeInputDefinition {
+            name: "disable".to_owned(),
+            display_name: title_case_name("disable"),
+            value_kind: ValueKind::Float,
+            accepted_kinds: vec![],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+    ],
     outputs: vec![],
     parameters: vec![
         NodeParameterDefinition::new(
@@ -1996,13 +2005,22 @@ static WLED_DUMMY_DISPLAY_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(||
     display_name: "Wled Dummy Display".to_owned(),
     category: NodeCategory::Debug,
     needs_io: false,
-    inputs: vec![NodeInputDefinition {
-        name: "value".to_owned(),
-        display_name: title_case_name("value"),
-        value_kind: ValueKind::ColorFrame,
-        accepted_kinds: vec![ValueKind::Color],
-        default_value: None,
-    }],
+    inputs: vec![
+        NodeInputDefinition {
+            name: "value".to_owned(),
+            display_name: title_case_name("value"),
+            value_kind: ValueKind::ColorFrame,
+            accepted_kinds: vec![ValueKind::Color],
+            default_value: None,
+        },
+        NodeInputDefinition {
+            name: "disable".to_owned(),
+            display_name: title_case_name("disable"),
+            value_kind: ValueKind::Float,
+            accepted_kinds: vec![],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+    ],
     outputs: vec![],
     parameters: vec![
         NodeParameterDefinition::new(


### PR DESCRIPTION
## Summary
Add a `disable` input to both `Wled Target` and `Wled Dummy Display` so graph logic can turn these output-style nodes off at runtime.

## Why
Issue #20 asks for a graph-controlled way to mute physical WLED output and disable the dummy preview display without removing connections or restructuring the graph.

## What changed
- added a float `disable` input to the shared node definitions for `Wled Target` and `Wled Dummy Display`
- `Wled Target` now treats `disable >= 0.5` as disabled and skips DDP frame transmission
- `Wled Target` still preserves useful diagnostics while disabled, including missing target configuration warnings
- `Wled Dummy Display` now treats `disable >= 0.5` as disabled and emits a black preview frame so the frontend shows a clear off state instead of a stale last frame
- added focused backend tests for the disable threshold and disabled-state behavior

## Testing
- `cargo fmt --all`
- `cargo test -p shared -p backend --locked`

## Compatibility
- no persisted graph format break
- existing graphs remain compatible because the new input defaults to enabled (`0.0`)

Closes #20