### PR TITLE
fix(frontend): keep editor layout stable for frame inputs

### DIFF
--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -63,6 +63,79 @@ impl eframe::App for FrontendApp {
 }
 
 impl FrontendApp {
+    /// Rebuilds the live editor snarl from the currently loaded document.
+    pub(crate) fn rebuild_live_snarl_from_loaded_document(&mut self) {
+        let Some(document) = self.graphs.loaded_graph_document.clone() else {
+            self.graphs.live_snarl_graph_id = None;
+            self.graphs.live_snarl = None;
+            self.graphs.live_snarl_needs_rebuild = false;
+            return;
+        };
+
+        self.graphs.live_snarl_graph_id = Some(document.metadata.id.clone());
+        self.graphs.live_snarl = Some(crate::editor_view::build_snarl_from_document(
+            &document,
+            &self.graphs.available_node_definitions,
+            &self.graphs.runtime_node_values,
+        ));
+        self.graphs.live_snarl_needs_rebuild = false;
+    }
+
+    /// Synchronizes the live snarl with the currently loaded document, patching in place when
+    /// possible so surviving nodes keep their `egui_snarl` identities across history restores.
+    pub(crate) fn sync_live_snarl_from_loaded_document(&mut self) {
+        let Some(document) = self.graphs.loaded_graph_document.clone() else {
+            self.graphs.live_snarl_graph_id = None;
+            self.graphs.live_snarl = None;
+            self.graphs.live_snarl_needs_rebuild = false;
+            return;
+        };
+
+        let loaded_graph_id = document.metadata.id.clone();
+        let can_patch = self.graphs.live_snarl_graph_id.as_deref()
+            == Some(loaded_graph_id.as_str())
+            && self.graphs.live_snarl.is_some();
+
+        if can_patch {
+            if let Some(snarl) = self.graphs.live_snarl.as_mut() {
+                crate::editor_view::patch_snarl_from_document(
+                    snarl,
+                    &document,
+                    &self.graphs.available_node_definitions,
+                    &self.graphs.runtime_node_values,
+                );
+            }
+            self.graphs.live_snarl_needs_rebuild = false;
+            return;
+        }
+
+        self.rebuild_live_snarl_from_loaded_document();
+    }
+
+    /// Ensures the selected graph has a live snarl instance ready for rendering.
+    pub(crate) fn ensure_live_snarl_for_active_graph(&mut self) {
+        let Some(selected_graph_id) = self.ui.selected_graph_id.as_deref() else {
+            return;
+        };
+        let loaded_graph_id = self
+            .graphs
+            .loaded_graph_document
+            .as_ref()
+            .map(|document| document.metadata.id.as_str());
+        if loaded_graph_id != Some(selected_graph_id) {
+            return;
+        }
+
+        let live_graph_matches =
+            self.graphs.live_snarl_graph_id.as_deref() == Some(selected_graph_id);
+        if self.graphs.live_snarl.is_none()
+            || !live_graph_matches
+            || self.graphs.live_snarl_needs_rebuild
+        {
+            self.sync_live_snarl_from_loaded_document();
+        }
+    }
+
     /// Restores a graph-history snapshot while preserving the current editor viewport.
     ///
     /// Undo and redo intentionally treat camera movement as transient UI state, so history
@@ -75,6 +148,8 @@ impl FrontendApp {
         self.graphs.history_committed_document = Some(document.clone());
         self.graphs.save_in_flight_document = None;
         self.graphs.graph_update_last_observed_document = Some(document);
+        self.graphs.live_snarl_needs_rebuild = false;
+        self.sync_live_snarl_from_loaded_document();
         self.clear_pending_graph_update_tracking();
     }
 }

--- a/crates/frontend/src/app/navigation.rs
+++ b/crates/frontend/src/app/navigation.rs
@@ -179,6 +179,31 @@ impl FrontendApp {
         self.graphs.loaded_graph_document.as_mut()
     }
 
+    /// Returns the loaded graph document and live snarl when both match the selected graph.
+    pub(crate) fn active_graph_document_and_snarl_mut(
+        &mut self,
+    ) -> Option<(
+        &mut shared::GraphDocument,
+        &mut egui_snarl::Snarl<crate::editor_view::EditorSnarlNode>,
+    )> {
+        let selected_id = self.ui.selected_graph_id.as_deref()?;
+        let loaded_id = self
+            .graphs
+            .loaded_graph_document
+            .as_ref()
+            .map(|document| document.metadata.id.as_str())?;
+        let live_graph_id = self.graphs.live_snarl_graph_id.as_deref()?;
+        if loaded_id != selected_id || live_graph_id != selected_id {
+            return None;
+        }
+
+        let graphs = &mut self.graphs;
+        Some((
+            graphs.loaded_graph_document.as_mut()?,
+            graphs.live_snarl.as_mut()?,
+        ))
+    }
+
     /// Requests the selected graph document from the backend when it is not already loaded.
     ///
     /// Repeated requests for the same graph are suppressed while a previous request is still
@@ -224,6 +249,9 @@ impl FrontendApp {
         self.graphs.save_in_flight_document = None;
         self.clear_pending_graph_update_tracking();
         self.graphs.snarl_viewport_initialized_graph_id = None;
+        self.graphs.live_snarl_graph_id = None;
+        self.graphs.live_snarl = None;
+        self.graphs.live_snarl_needs_rebuild = false;
         self.graphs.runtime_node_values.clear();
         self.ui.diagnostics_window_graph_id = None;
         self.ui.diagnostics_window_node_id = None;

--- a/crates/frontend/src/app/server_state.rs
+++ b/crates/frontend/src/app/server_state.rs
@@ -101,13 +101,15 @@ impl FrontendApp {
         self.graphs.loaded_graph_document = Some(document.clone());
         self.reset_graph_history(Some(document));
         self.graphs.save_in_flight_document = None;
-        self.clear_pending_graph_update_tracking();
 
         if !same_loaded_graph {
             self.graphs.snarl_viewport_initialized_graph_id = None;
             self.graphs.runtime_node_values.clear();
             self.graphs.plot_history.clear();
         }
+
+        self.sync_live_snarl_from_loaded_document();
+        self.clear_pending_graph_update_tracking();
 
         info!(graph_id = %graph_id, "frontend loaded graph document");
         self.ui.status = "Graph document loaded".to_owned();
@@ -131,6 +133,7 @@ impl FrontendApp {
         if current_document_matches_ack {
             self.graphs.loaded_graph_document = Some(document.clone());
             self.graphs.history_committed_document = Some(document);
+            self.sync_live_snarl_from_loaded_document();
             self.clear_pending_graph_update_tracking();
             info!(graph_id = %graph_id, "frontend save acknowledged");
             self.ui.status = "Graph document saved".to_owned();
@@ -143,6 +146,8 @@ impl FrontendApp {
     /// Replaces the set of node definitions available to the editor palette.
     pub(crate) fn apply_node_definitions(&mut self, definitions: Vec<NodeDefinition>) {
         self.graphs.available_node_definitions = definitions;
+        self.graphs.live_snarl_needs_rebuild = false;
+        self.sync_live_snarl_from_loaded_document();
         self.ui.status = "Node definitions updated".to_owned();
     }
 
@@ -278,6 +283,9 @@ impl FrontendApp {
         self.graphs.save_in_flight_document = None;
         self.clear_pending_graph_update_tracking();
         self.graphs.snarl_viewport_initialized_graph_id = None;
+        self.graphs.live_snarl_graph_id = None;
+        self.graphs.live_snarl = None;
+        self.graphs.live_snarl_needs_rebuild = false;
         self.graphs.runtime_node_values.clear();
         self.graphs.plot_history.clear();
         self.ui.diagnostics_window_graph_id = None;
@@ -316,9 +324,33 @@ fn decode_runtime_update_value(value: NodeRuntimeUpdateValue) -> (String, InputV
 
 #[cfg(test)]
 mod tests {
-    use shared::{NodeDiagnosticEntry, NodeDiagnosticSeverity, NodeDiagnosticSummary};
+    use shared::{
+        GraphDocument, GraphNode, NodeDiagnosticEntry, NodeDiagnosticSeverity,
+        NodeDiagnosticSummary, NodeMetadata, NodeTypeId, NodeViewport,
+    };
 
     use crate::app::FrontendApp;
+
+    fn graph_document_with_node_title(title: &str) -> GraphDocument {
+        GraphDocument {
+            metadata: shared::GraphMetadata {
+                id: "graph-a".to_owned(),
+                name: "Graph A".to_owned(),
+                execution_frequency_hz: 60,
+            },
+            nodes: vec![GraphNode {
+                id: "node-1".to_owned(),
+                metadata: NodeMetadata {
+                    name: title.to_owned(),
+                },
+                node_type: NodeTypeId::new("test.unknown"),
+                viewport: NodeViewport::default(),
+                input_values: Vec::new(),
+                parameters: Vec::new(),
+            }],
+            ..GraphDocument::default()
+        }
+    }
 
     #[test]
     fn graph_diagnostics_are_cached_by_graph_id() {
@@ -350,5 +382,20 @@ mod tests {
             Some(1)
         );
         assert_eq!(app.node_diagnostic_details("graph-a", "node-1").len(), 1);
+    }
+
+    #[test]
+    fn save_acknowledgement_resyncs_cached_live_snarl() {
+        let mut app = FrontendApp::default();
+        let local_document = graph_document_with_node_title("Local Title");
+        app.graphs.loaded_graph_document = Some(local_document);
+        app.rebuild_live_snarl_from_loaded_document();
+
+        let acknowledged_document = graph_document_with_node_title("Backend Title");
+        app.acknowledge_graph_save(acknowledged_document, true);
+
+        let live_snarl = app.graphs.live_snarl.as_ref().expect("live snarl");
+        let node_titles = crate::editor_view::snarl_node_titles(live_snarl);
+        assert_eq!(node_titles, vec!["Backend Title".to_owned()]);
     }
 }

--- a/crates/frontend/src/editor_view.rs
+++ b/crates/frontend/src/editor_view.rs
@@ -13,7 +13,7 @@ mod widgets;
 
 #[derive(Clone)]
 /// Editor-side representation of a single input port on a rendered node card.
-struct EditorInputPort {
+pub(crate) struct EditorInputPort {
     name: String,
     display_name: String,
     value_kind: ValueKind,
@@ -22,7 +22,7 @@ struct EditorInputPort {
 
 #[derive(Clone)]
 /// Editor-side representation of a single output port on a rendered node card.
-struct EditorOutputPort {
+pub(crate) struct EditorOutputPort {
     name: String,
     display_name: String,
     value_kind: ValueKind,
@@ -31,7 +31,7 @@ struct EditorOutputPort {
 
 #[derive(Clone)]
 /// Editor-side representation of a graph node as shown on the snarl canvas.
-struct EditorSnarlNode {
+pub(crate) struct EditorSnarlNode {
     graph_node_id: String,
     title: String,
     node_type_id: String,
@@ -39,6 +39,17 @@ struct EditorSnarlNode {
     outputs: Vec<EditorOutputPort>,
     parameters: Vec<NodeParameter>,
     runtime_values: Vec<(String, InputValue)>,
+}
+
+pub(crate) use self::model::{
+    build_snarl_from_document, patch_snarl_from_document, refresh_snarl_runtime_values,
+};
+
+#[cfg(test)]
+pub(crate) fn snarl_node_titles(
+    snarl: &egui_snarl::Snarl<EditorSnarlNode>,
+) -> Vec<String> {
+    snarl.nodes().map(|node| node.title.clone()).collect()
 }
 
 /// Renders the graph editor view, including header controls, the node canvas, and diagnostics UI.
@@ -186,7 +197,8 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                 .ui
                 .node_menu_graph_position
                 .map(|(x, y)| egui::pos2(x, y));
-            if let Some(document) = app.active_graph_document_mut() {
+            app.ensure_live_snarl_for_active_graph();
+            if let Some((document, snarl)) = app.active_graph_document_and_snarl_mut() {
                 if available_node_definitions.is_empty() {
                     egui::Frame::group(ui.style()).show(ui, |ui| {
                         ui.set_min_height(100.0);
@@ -198,6 +210,11 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                     });
                     return;
                 }
+                refresh_snarl_runtime_values(
+                    snarl,
+                    &available_node_definitions,
+                    &runtime_node_values,
+                );
                 let (
                     initialized,
                     opened_diagnostics_node_id,
@@ -206,9 +223,9 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                     node_menu_graph_position,
                 ) = viewer::show_snarl_canvas(
                     ui,
+                    snarl,
                     document,
                     &available_node_definitions,
-                    &runtime_node_values,
                     &plot_history,
                     &diagnostic_summaries,
                     &wled_instances,

--- a/crates/frontend/src/editor_view/model.rs
+++ b/crates/frontend/src/editor_view/model.rs
@@ -12,7 +12,7 @@ use super::{EditorInputPort, EditorOutputPort, EditorSnarlNode};
 ///
 /// Node positions, collapsed state, wires, schema-driven defaults, and live runtime values are
 /// all projected into the editor model used by `egui_snarl`.
-pub(super) fn build_snarl_from_document(
+pub(crate) fn build_snarl_from_document(
     document: &GraphDocument,
     available_node_definitions: &[NodeDefinition],
     runtime_node_values: &HashMap<String, HashMap<String, InputValue>>,
@@ -75,7 +75,7 @@ pub(super) fn build_snarl_from_document(
 ///
 /// This updates node positions, collapsed state, titles, input values, parameters, and edges so
 /// the document can be autosaved or sent back to the backend.
-pub(super) fn sync_document_from_snarl(
+pub(crate) fn sync_document_from_snarl(
     document: &mut GraphDocument,
     snarl: &Snarl<EditorSnarlNode>,
 ) {
@@ -463,6 +463,154 @@ pub(super) fn find_node_definition<'a>(
     available_node_definitions
         .iter()
         .find(|definition| definition.id == node_type_id)
+}
+
+/// Refreshes live runtime values on an existing editor snarl without rebuilding node identities.
+pub(crate) fn refresh_snarl_runtime_values(
+    snarl: &mut Snarl<EditorSnarlNode>,
+    available_node_definitions: &[NodeDefinition],
+    runtime_node_values: &HashMap<String, HashMap<String, InputValue>>,
+) {
+    for (_node_id, editor_node) in snarl.nodes_ids_mut() {
+        let runtime_values = runtime_node_values.get(editor_node.graph_node_id.as_str());
+
+        if find_node_definition(available_node_definitions, &editor_node.node_type_id).is_some() {
+            for output in &mut editor_node.outputs {
+                output.runtime_value = runtime_values
+                    .and_then(|values| values.get(&output.name))
+                    .cloned();
+            }
+        } else {
+            for output in &mut editor_node.outputs {
+                output.runtime_value = None;
+            }
+        }
+
+        editor_node.runtime_values = runtime_values
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|(name, value)| (name.clone(), value.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+    }
+}
+
+/// Patches an existing editor snarl to match the persisted graph document while preserving
+/// surviving node identities and their cached egui layout state.
+pub(crate) fn patch_snarl_from_document(
+    snarl: &mut Snarl<EditorSnarlNode>,
+    document: &GraphDocument,
+    available_node_definitions: &[NodeDefinition],
+    runtime_node_values: &HashMap<String, HashMap<String, InputValue>>,
+) {
+    let mut existing_node_ids = HashMap::<String, NodeId>::new();
+    for (node_id, editor_node) in snarl.nodes_ids_mut() {
+        existing_node_ids.insert(editor_node.graph_node_id.clone(), node_id);
+    }
+
+    let document_node_ids = document
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+
+    let removed_node_ids = existing_node_ids
+        .iter()
+        .filter_map(|(graph_node_id, node_id)| {
+            (!document_node_ids.contains(graph_node_id.as_str())).then_some(*node_id)
+        })
+        .collect::<Vec<_>>();
+    for node_id in removed_node_ids {
+        snarl.remove_node(node_id);
+    }
+
+    existing_node_ids.clear();
+    for (node_id, editor_node) in snarl.nodes_ids_mut() {
+        existing_node_ids.insert(editor_node.graph_node_id.clone(), node_id);
+    }
+
+    for node in &document.nodes {
+        let runtime_values = runtime_node_values.get(&node.id);
+        let refreshed_editor_node =
+            editor_node_from_graph_node(node, available_node_definitions, runtime_values);
+
+        if let Some(existing_node_id) = existing_node_ids.get(node.id.as_str()).copied() {
+            if let Some(editor_node) = snarl.get_node_mut(existing_node_id) {
+                *editor_node = refreshed_editor_node;
+            }
+            if let Some(node_info) = snarl.get_node_info_mut(existing_node_id) {
+                node_info.pos = egui::pos2(node.viewport.position.x, node.viewport.position.y);
+            }
+            snarl.open_node(existing_node_id, !node.viewport.collapsed);
+            continue;
+        }
+
+        let inserted_node_id = if node.viewport.collapsed {
+            snarl.insert_node_collapsed(
+                egui::pos2(node.viewport.position.x, node.viewport.position.y),
+                refreshed_editor_node,
+            )
+        } else {
+            snarl.insert_node(
+                egui::pos2(node.viewport.position.x, node.viewport.position.y),
+                refreshed_editor_node,
+            )
+        };
+        existing_node_ids.insert(node.id.clone(), inserted_node_id);
+    }
+
+    let input_pins = snarl
+        .nodes_ids_mut()
+        .map(|(node_id, editor_node)| {
+            (0..editor_node.inputs.len())
+                .map(|input_index| egui_snarl::InPinId {
+                    node: node_id,
+                    input: input_index,
+                })
+                .collect::<Vec<_>>()
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+    for input_pin in input_pins {
+        snarl.drop_inputs(input_pin);
+    }
+
+    for edge in &document.edges {
+        let Some(from_node_id) = existing_node_ids.get(&edge.from_node_id).copied() else {
+            continue;
+        };
+        let Some(to_node_id) = existing_node_ids.get(&edge.to_node_id).copied() else {
+            continue;
+        };
+
+        let Some(from_node) = snarl.get_node(from_node_id) else {
+            continue;
+        };
+        let Some(to_node) = snarl.get_node(to_node_id) else {
+            continue;
+        };
+
+        let Some(from_output_index) = output_port_index(&from_node.outputs, &edge.from_output_name)
+        else {
+            continue;
+        };
+        let Some(to_input_index) = input_port_index(&to_node.inputs, &edge.to_input_name) else {
+            continue;
+        };
+
+        snarl.connect(
+            egui_snarl::OutPinId {
+                node: from_node_id,
+                output: from_output_index,
+            },
+            egui_snarl::InPinId {
+                node: to_node_id,
+                input: to_input_index,
+            },
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/frontend/src/editor_view/viewer.rs
+++ b/crates/frontend/src/editor_view/viewer.rs
@@ -10,8 +10,8 @@ use shared::{
 
 use super::EditorSnarlNode;
 use super::model::{
-    build_snarl_from_document, editor_node_from_definition, find_node_definition,
-    sync_document_from_snarl, visible_parameter_definitions,
+    editor_node_from_definition, find_node_definition, sync_document_from_snarl,
+    visible_parameter_definitions,
 };
 use super::widgets::{
     draw_color_frame_preview, draw_float_plot, edit_input_value, edit_parameter_value,
@@ -441,12 +441,9 @@ fn render_graph_menu_contents(
 /// node-menu search text, and the next graph-space position for the add-node menu.
 pub(super) fn show_snarl_canvas(
     ui: &mut egui::Ui,
+    mut snarl: &mut Snarl<EditorSnarlNode>,
     document: &mut GraphDocument,
     available_node_definitions: &[NodeDefinition],
-    runtime_node_values: &std::collections::HashMap<
-        String,
-        std::collections::HashMap<String, shared::InputValue>,
-    >,
     plot_history: &std::collections::HashMap<String, std::collections::VecDeque<f32>>,
     diagnostic_summaries: &std::collections::HashMap<String, NodeDiagnosticSummary>,
     wled_instances: &[WledInstance],
@@ -461,8 +458,6 @@ pub(super) fn show_snarl_canvas(
         center_viewport_on_nodes(document, canvas_size);
     }
 
-    let mut snarl =
-        build_snarl_from_document(document, available_node_definitions, runtime_node_values);
     let should_apply_transform = apply_document_viewport || focus_requested;
     let initial_transform = if should_apply_transform {
         Some(TSTransform::new(

--- a/crates/frontend/src/editor_view/widgets.rs
+++ b/crates/frontend/src/editor_view/widgets.rs
@@ -1,7 +1,7 @@
 use serde_json::Value as JsonValue;
 use shared::{
     ColorGradient, ColorGradientStop, InputValue, MqttBrokerConfig, NodeDefinition, NodeParameter,
-    ParameterUiHint, RgbaColor, WledInstance,
+    ParameterUiHint, RgbaColor, ValueKind, WledInstance,
 };
 
 use super::model::{coerce_input_value_kind, parameters_with_defaults};
@@ -236,6 +236,9 @@ pub(super) fn draw_float_plot(ui: &mut egui::Ui, samples: &[f32]) {
 /// not leak into the editor UI.
 pub(super) fn edit_input_value(ui: &mut egui::Ui, input: &mut EditorInputPort) {
     input.value = coerce_input_value_kind(input.value.clone(), input.value_kind);
+    if !supports_disconnected_inline_editor(input.value_kind) {
+        return;
+    }
     match &mut input.value {
         InputValue::Float(value) => {
             ui.add(
@@ -262,9 +265,19 @@ pub(super) fn edit_input_value(ui: &mut egui::Ui, input: &mut EditorInputPort) {
         InputValue::LedLayout(layout) => {
             ui.label(format!("{} LEDs ({})", layout.pixel_count, layout.id));
         }
-        InputValue::ColorFrame(frame) => {
-            ui.label(format!("{} LEDs ({})", frame.pixels.len(), frame.layout.id));
-        }
+        InputValue::ColorFrame(_) => {}
+    }
+}
+
+/// Returns whether a disconnected input kind should render an inline editor in the node row.
+pub(super) fn supports_disconnected_inline_editor(kind: ValueKind) -> bool {
+    match kind {
+        ValueKind::Any => true,
+        ValueKind::Float => true,
+        ValueKind::FloatTensor => true,
+        ValueKind::Color => true,
+        ValueKind::LedLayout => true,
+        ValueKind::ColorFrame => false,
     }
 }
 
@@ -832,8 +845,8 @@ pub(super) fn max_input_label_width(ui: &egui::Ui, node: &EditorSnarlNode) -> f3
 
 #[cfg(test)]
 mod tests {
-    use super::frame_preview_dimensions;
-    use shared::{ColorFrame, LedLayout, RgbaColor};
+    use super::{frame_preview_dimensions, supports_disconnected_inline_editor};
+    use shared::{ColorFrame, LedLayout, RgbaColor, ValueKind};
 
     #[test]
     fn one_dimensional_layout_is_rendered_as_horizontal_strip() {
@@ -879,5 +892,10 @@ mod tests {
         };
 
         assert_eq!(frame_preview_dimensions(&frame), (4, 3));
+    }
+
+    #[test]
+    fn color_frame_inputs_do_not_render_disconnected_inline_editors() {
+        assert!(!supports_disconnected_inline_editor(ValueKind::ColorFrame));
     }
 }

--- a/crates/frontend/src/state.rs
+++ b/crates/frontend/src/state.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use eframe::egui;
+use egui_snarl::Snarl;
 use futures_channel::mpsc;
 use shared::{
     EventSubscription, GraphDocument, GraphExchangeFile, GraphMetadata, GraphRuntimeMode,
@@ -86,6 +87,9 @@ pub(crate) struct GraphState {
     pub(crate) graph_update_last_change_secs: Option<f64>,
     pub(crate) graph_update_last_observed_document: Option<GraphDocument>,
     pub(crate) snarl_viewport_initialized_graph_id: Option<String>,
+    pub(crate) live_snarl_graph_id: Option<String>,
+    pub(crate) live_snarl: Option<Snarl<crate::editor_view::EditorSnarlNode>>,
+    pub(crate) live_snarl_needs_rebuild: bool,
     pub(crate) graph_runtime_modes: HashMap<String, GraphRuntimeMode>,
     pub(crate) runtime_node_values: HashMap<String, HashMap<String, InputValue>>,
     pub(crate) plot_history: HashMap<String, VecDeque<f32>>,
@@ -115,6 +119,9 @@ impl Default for GraphState {
             graph_update_last_change_secs: None,
             graph_update_last_observed_document: None,
             snarl_viewport_initialized_graph_id: None,
+            live_snarl_graph_id: None,
+            live_snarl: None,
+            live_snarl_needs_rebuild: false,
             graph_runtime_modes: HashMap::new(),
             runtime_node_values: HashMap::new(),
             plot_history: HashMap::new(),


### PR DESCRIPTION
## Summary
- cache the editor snarl so node UI layout state survives document resyncs and undo/redo
- stop rendering disconnected inline editors for `ColorFrame` inputs to avoid row height jumps
- resync the cached live snarl when a save acknowledgement updates the loaded document
- add regression coverage for the cached-snarl save acknowledgement path

## Why
`ColorFrame` inputs were causing layout jumps in the editor, and the new cached snarl approach also needed one extra sync on save acknowledgements so the canvas stays aligned with backend-normalized documents.

## Testing
- `cargo test -p frontend --locked`

## Compatibility Notes
- no persisted graph format changes
- no protocol or backend contract changes