### PR TITLE
feat(nodes): add uploaded image source node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .direnv
 crates/backend/data/*
 !examples/*
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ dist
 node_modules
 .DS_Store
 .direnv
-*.json
+crates/backend/data/*
 !examples/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,9 +196,11 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http",
+ "image",
  "libblur",
  "mdns-sd",
  "palette",
+ "resvg",
  "rumqttc",
  "serde",
  "serde_json",
@@ -367,6 +381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +477,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +555,12 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "digest"
@@ -775,6 +810,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +898,29 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -898,6 +971,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "js-sys",
+ "serde",
  "serde_json",
  "shared",
  "tracing",
@@ -1016,6 +1090,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1379,11 +1463,32 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"
@@ -1501,6 +1606,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1656,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2170,6 +2292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,6 +2562,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2599,21 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2561,6 +2730,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -2760,6 +2947,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,10 +3071,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -2966,6 +3187,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +3221,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3201,6 +3463,9 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "tungstenite"
@@ -3232,16 +3497,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-xid"
@@ -3265,6 +3566,34 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -4051,6 +4380,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yoke"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -29,7 +29,9 @@ axum.workspace = true
 flume = "0.11"
 futures-util.workspace = true
 http.workspace = true
+image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "webp"] }
 mdns-sd = "0.13"
+resvg = "0.47"
 rumqttc = "0.24"
 socket2 = "0.5"
 tokio.workspace = true

--- a/crates/backend/src/api/http.rs
+++ b/crates/backend/src/api/http.rs
@@ -1,6 +1,13 @@
 use std::path::PathBuf;
 
-use axum::{Router, routing::get};
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+};
+use serde::Serialize;
 use tower_http::{
     services::{ServeDir, ServeFile},
     trace::TraceLayer,
@@ -20,6 +27,7 @@ pub(crate) fn router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(|| async { "ok" }))
         .route("/ws", get(websocket_handler))
+        .route("/api/assets/images", post(upload_image_asset))
         .fallback_service(
             ServeDir::new(dist_dir)
                 .append_index_html_on_directories(true)
@@ -27,6 +35,33 @@ pub(crate) fn router(state: AppState) -> Router {
         )
         .with_state(state)
         .layer(TraceLayer::new_for_http())
+}
+
+#[derive(Debug, Serialize)]
+struct UploadImageAssetResponse {
+    asset_id: String,
+}
+
+/// Persists an uploaded image asset and returns the stable id the graph should reference.
+async fn upload_image_asset(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> Result<Json<UploadImageAssetResponse>, (StatusCode, String)> {
+    let asset_id = state
+        .image_asset_store
+        .store_image_bytes(body.as_ref())
+        .map_err(invalid_upload_response)?;
+    Ok(Json(UploadImageAssetResponse { asset_id }))
+}
+
+fn invalid_upload_response(error: anyhow::Error) -> (StatusCode, String) {
+    let message = error.to_string();
+    let status = if message.contains("decode uploaded image") || message.contains("empty") {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::INTERNAL_SERVER_ERROR
+    };
+    (status, message)
 }
 
 /// Returns the filesystem path containing the built frontend assets served by the backend.

--- a/crates/backend/src/app/startup.rs
+++ b/crates/backend/src/app/startup.rs
@@ -10,6 +10,7 @@ use crate::app::state::AppState;
 use crate::messaging::event_bus::EventBus;
 use crate::node_runtime::build_builtin_node_registry;
 use crate::services::graph_store::GraphStore;
+use crate::services::image_asset_store::{ImageAssetStore, set_global_image_asset_store};
 use crate::services::mqtt::{HomeAssistantMqttService, set_global_home_assistant_mqtt_service};
 use crate::services::mqtt_broker_store::MqttBrokerStore;
 use crate::services::runtime::manager::GraphRuntimeManager;
@@ -24,9 +25,11 @@ pub(crate) async fn build_app_state() -> anyhow::Result<AppState> {
     let event_bus = EventBus::default();
     let node_registry = build_builtin_node_registry()?;
     let graph_store = Arc::new(GraphStore::new(&data_dir, Arc::new(event_bus.clone())));
+    let image_asset_store = Arc::new(ImageAssetStore::new(&data_dir)?);
     let mqtt_broker_store = Arc::new(MqttBrokerStore::new(&data_dir));
     let mqtt_service = HomeAssistantMqttService::new();
     mqtt_service.sync_brokers(mqtt_broker_store.list().await?)?;
+    set_global_image_asset_store(image_asset_store.clone())?;
     set_global_home_assistant_mqtt_service(mqtt_service.clone())?;
     let runtime_manager = Arc::new(GraphRuntimeManager::new(
         &data_dir,
@@ -44,6 +47,7 @@ pub(crate) async fn build_app_state() -> anyhow::Result<AppState> {
         event_bus,
         node_registry,
         graph_store,
+        image_asset_store,
         mqtt_broker_store,
         mqtt_service,
         runtime_manager,

--- a/crates/backend/src/app/state.rs
+++ b/crates/backend/src/app/state.rs
@@ -6,6 +6,7 @@ use tokio::sync::RwLock;
 use crate::messaging::event_bus::EventBus;
 use crate::node_runtime::NodeRegistry;
 use crate::services::graph_store::GraphStore;
+use crate::services::image_asset_store::ImageAssetStore;
 use crate::services::mqtt::HomeAssistantMqttService;
 use crate::services::mqtt_broker_store::MqttBrokerStore;
 use crate::services::runtime::manager::GraphRuntimeManager;
@@ -18,6 +19,7 @@ pub(crate) struct AppState {
     pub(crate) event_bus: EventBus,
     pub(crate) node_registry: Arc<NodeRegistry>,
     pub(crate) graph_store: Arc<GraphStore>,
+    pub(crate) image_asset_store: Arc<ImageAssetStore>,
     pub(crate) mqtt_broker_store: Arc<MqttBrokerStore>,
     pub(crate) mqtt_service: Arc<HomeAssistantMqttService>,
     pub(crate) runtime_manager: Arc<GraphRuntimeManager>,

--- a/crates/backend/src/node_runtime/nodes/inputs/image_source.rs
+++ b/crates/backend/src/node_runtime/nodes/inputs/image_source.rs
@@ -1,0 +1,621 @@
+use anyhow::{Context, Result};
+use image::RgbaImage;
+use resvg::{
+    tiny_skia::{Pixmap, Transform},
+    usvg::Tree,
+};
+use shared::{ColorFrame, LedLayout, NodeDiagnostic, NodeDiagnosticSeverity, RgbaColor};
+use std::io::ErrorKind;
+use std::time::{Duration, Instant};
+
+use crate::node_runtime::{NodeEvaluationContext, RuntimeNode, TypedNodeEvaluation};
+use crate::services::image_asset_store::global_image_asset_store;
+use crate::services::image_codec::parse_svg;
+
+const IMAGE_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+#[derive(Default)]
+pub(crate) struct ImageSourceNode {
+    asset_id: String,
+    fit_mode: String,
+    cached_source: Option<CachedImageSource>,
+}
+
+crate::node_runtime::impl_runtime_parameters!(ImageSourceNode {
+    asset_id: String = String::new(),
+    fit_mode: String = "contain".to_owned(),
+    ..Default::default()
+});
+
+pub(crate) struct ImageSourceOutputs {
+    frame: ColorFrame,
+}
+
+crate::node_runtime::impl_runtime_outputs!(ImageSourceOutputs { frame });
+
+impl RuntimeNode for ImageSourceNode {
+    type Inputs = ();
+    type Outputs = ImageSourceOutputs;
+
+    fn evaluate(
+        &mut self,
+        context: &NodeEvaluationContext,
+        _inputs: Self::Inputs,
+    ) -> Result<TypedNodeEvaluation<Self::Outputs>> {
+        let layout_hint = context.render_layout.clone();
+        let fit_mode = self.fit_mode();
+        let asset_id = self.asset_id.trim().to_owned();
+        if asset_id.is_empty() {
+            return Ok(TypedNodeEvaluation {
+                outputs: ImageSourceOutputs {
+                    frame: transparent_frame(layout_hint.as_ref()),
+                },
+                frontend_updates: Vec::new(),
+                diagnostics: vec![NodeDiagnostic {
+                    severity: NodeDiagnosticSeverity::Warning,
+                    code: Some("image_source_missing_source".to_owned()),
+                    message: "No uploaded image selected.".to_owned(),
+                }],
+            });
+        }
+
+        let mut diagnostics = Vec::new();
+        let source = match self.ensure_source(&asset_id) {
+            Ok(source) => source,
+            Err(error) => {
+                if self.mark_failure_logged(&asset_id) {
+                    tracing::warn!(
+                        asset_id = %asset_id,
+                        error = %format_error_chain(&error),
+                        "failed to load image source asset"
+                    );
+                }
+                diagnostics.push(NodeDiagnostic {
+                    severity: NodeDiagnosticSeverity::Error,
+                    code: Some("image_source_load_failed".to_owned()),
+                    message: user_facing_load_error_message(&asset_id, &error),
+                });
+                return Ok(TypedNodeEvaluation {
+                    outputs: ImageSourceOutputs {
+                        frame: transparent_frame(layout_hint.as_ref()),
+                    },
+                    frontend_updates: Vec::new(),
+                    diagnostics,
+                });
+            }
+        };
+
+        let layout = target_layout(layout_hint, source);
+        Ok(TypedNodeEvaluation {
+            outputs: ImageSourceOutputs {
+                frame: render_source_to_frame(source, &layout, fit_mode)?,
+            },
+            frontend_updates: Vec::new(),
+            diagnostics,
+        })
+    }
+}
+
+impl ImageSourceNode {
+    fn fit_mode(&self) -> ImageFitMode {
+        match self.fit_mode.trim() {
+            "stretch" => ImageFitMode::Stretch,
+            "cover" => ImageFitMode::Cover,
+            _ => ImageFitMode::Contain,
+        }
+    }
+
+    fn ensure_source(&mut self, asset_id: &str) -> Result<&DecodedSource> {
+        let failure_message = match self.cached_source.as_ref() {
+            Some(CachedImageSource::Loaded {
+                asset_id: cached_id,
+                ..
+            }) if cached_id == asset_id => {
+                return match self.cached_source.as_ref() {
+                    Some(CachedImageSource::Loaded { source, .. }) => Ok(source),
+                    _ => anyhow::bail!("Image source cache changed unexpectedly"),
+                };
+            }
+            Some(CachedImageSource::Failed {
+                asset_id: cached_id,
+                message,
+                retry_after,
+                ..
+            }) if cached_id == asset_id && Instant::now() < *retry_after => Some(message.clone()),
+            _ => None,
+        };
+
+        if let Some(message) = failure_message {
+            anyhow::bail!("{message}");
+        }
+
+        match load_uploaded_image(asset_id) {
+            Ok(source) => {
+                self.cached_source = Some(CachedImageSource::Loaded {
+                    asset_id: asset_id.to_owned(),
+                    source,
+                });
+            }
+            Err(error) => {
+                let message = format_error_chain(&error);
+                self.cached_source = Some(CachedImageSource::Failed {
+                    asset_id: asset_id.to_owned(),
+                    message: message.clone(),
+                    retry_after: Instant::now() + IMAGE_FAILURE_RETRY_DELAY,
+                    warning_emitted: false,
+                });
+                anyhow::bail!("{message}");
+            }
+        }
+
+        match self.cached_source.as_ref() {
+            Some(CachedImageSource::Loaded { source, .. }) => Ok(source),
+            _ => anyhow::bail!("Image source did not produce a cached source"),
+        }
+    }
+
+    fn mark_failure_logged(&mut self, asset_id: &str) -> bool {
+        match self.cached_source.as_mut() {
+            Some(CachedImageSource::Failed {
+                asset_id: cached_id,
+                warning_emitted,
+                ..
+            }) if cached_id == asset_id && !*warning_emitted => {
+                *warning_emitted = true;
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+enum CachedImageSource {
+    Loaded {
+        asset_id: String,
+        source: DecodedSource,
+    },
+    Failed {
+        asset_id: String,
+        message: String,
+        retry_after: Instant,
+        warning_emitted: bool,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum ImageFitMode {
+    Stretch,
+    Contain,
+    Cover,
+}
+
+enum DecodedSource {
+    Raster(RgbaImage),
+    Svg(Tree),
+}
+
+fn load_uploaded_image(asset_id: &str) -> Result<DecodedSource> {
+    let store = global_image_asset_store()
+        .context("Uploaded image storage is unavailable in this backend process")?;
+    let bytes = store
+        .load_image_bytes(asset_id)
+        .with_context(|| format!("Load uploaded image asset '{asset_id}'"))?;
+    decode_image_source(&bytes, None)
+}
+
+fn decode_image_source(bytes: &[u8], content_type: Option<&str>) -> Result<DecodedSource> {
+    if is_svg_payload(bytes, content_type) {
+        return Ok(DecodedSource::Svg(parse_svg(
+            bytes,
+            "Parse SVG image source",
+        )?));
+    }
+
+    Ok(DecodedSource::Raster(
+        image::load_from_memory(bytes)
+            .context("Decode image source")?
+            .into_rgba8(),
+    ))
+}
+
+fn is_svg_payload(bytes: &[u8], content_type: Option<&str>) -> bool {
+    if content_type.is_some_and(|value| value.contains("image/svg+xml")) {
+        return true;
+    }
+
+    crate::services::image_codec::is_svg_payload(bytes)
+}
+
+fn format_error_chain(error: &anyhow::Error) -> String {
+    let mut chain = error.chain();
+    let Some(first) = chain.next() else {
+        return "Unknown image source error".to_owned();
+    };
+
+    let mut message = first.to_string();
+    for cause in chain {
+        let cause = cause.to_string();
+        if !cause.is_empty() && cause != message {
+            message.push_str(": ");
+            message.push_str(&cause);
+        }
+    }
+    message
+}
+
+fn user_facing_load_error_message(asset_id: &str, error: &anyhow::Error) -> String {
+    if error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
+        .any(|io_error| io_error.kind() == ErrorKind::NotFound)
+    {
+        return format!("Uploaded image asset '{asset_id}' is missing.");
+    }
+
+    if error.to_string().contains("image asset id")
+        && error.to_string().contains("is invalid")
+    {
+        return "Uploaded image reference is invalid.".to_owned();
+    }
+
+    "Uploaded image asset could not be loaded.".to_owned()
+}
+
+fn target_layout(layout_hint: Option<LedLayout>, source: &DecodedSource) -> LedLayout {
+    layout_hint.unwrap_or_else(|| match source {
+        DecodedSource::Raster(source_image) => LedLayout {
+            id: "image_source".to_owned(),
+            pixel_count: source_image.width() as usize * source_image.height() as usize,
+            width: Some(source_image.width() as usize),
+            height: Some(source_image.height() as usize),
+        },
+        DecodedSource::Svg(tree) => {
+            let size = tree.size().to_int_size();
+            LedLayout {
+                id: "image_source".to_owned(),
+                pixel_count: size.width() as usize * size.height() as usize,
+                width: Some(size.width() as usize),
+                height: Some(size.height() as usize),
+            }
+        }
+    })
+}
+
+fn transparent_frame(layout_hint: Option<&LedLayout>) -> ColorFrame {
+    let layout = layout_hint.cloned().unwrap_or(LedLayout {
+        id: "image_source".to_owned(),
+        pixel_count: 0,
+        width: None,
+        height: None,
+    });
+    ColorFrame {
+        pixels: vec![transparent_black(); layout.pixel_count],
+        layout,
+    }
+}
+
+fn render_image_to_frame(
+    source_image: &RgbaImage,
+    layout: &LedLayout,
+    fit_mode: ImageFitMode,
+) -> ColorFrame {
+    let (target_width, target_height) = render_dimensions(layout);
+    let pixels = (0..target_height)
+        .flat_map(|y| {
+            (0..target_width).map(move |x| {
+                sample_source_image(source_image, x, y, target_width, target_height, fit_mode)
+            })
+        })
+        .collect();
+
+    ColorFrame {
+        layout: layout.clone(),
+        pixels,
+    }
+}
+
+fn render_source_to_frame(
+    source: &DecodedSource,
+    layout: &LedLayout,
+    fit_mode: ImageFitMode,
+) -> Result<ColorFrame> {
+    match source {
+        DecodedSource::Raster(source_image) => {
+            Ok(render_image_to_frame(source_image, layout, fit_mode))
+        }
+        DecodedSource::Svg(tree) => render_svg_to_frame(tree, layout, fit_mode),
+    }
+}
+
+fn render_svg_to_frame(
+    tree: &Tree,
+    layout: &LedLayout,
+    fit_mode: ImageFitMode,
+) -> Result<ColorFrame> {
+    let (target_width, target_height) = render_dimensions(layout);
+    let mut pixmap = Pixmap::new(target_width as u32, target_height as u32)
+        .context("Allocate SVG rasterization buffer")?;
+
+    let svg_size = tree.size();
+    let source_width = svg_size.width();
+    let source_height = svg_size.height();
+    let target_width_f32 = target_width as f32;
+    let target_height_f32 = target_height as f32;
+
+    let transform = match fit_mode {
+        ImageFitMode::Stretch => Transform::from_row(
+            target_width_f32 / source_width,
+            0.0,
+            0.0,
+            target_height_f32 / source_height,
+            0.0,
+            0.0,
+        ),
+        ImageFitMode::Contain | ImageFitMode::Cover => {
+            let scale_x = target_width_f32 / source_width;
+            let scale_y = target_height_f32 / source_height;
+            let scale = match fit_mode {
+                ImageFitMode::Contain => scale_x.min(scale_y),
+                ImageFitMode::Cover => scale_x.max(scale_y),
+                ImageFitMode::Stretch => unreachable!(),
+            };
+            let rendered_width = source_width * scale;
+            let rendered_height = source_height * scale;
+            let offset_x = (target_width_f32 - rendered_width) * 0.5;
+            let offset_y = (target_height_f32 - rendered_height) * 0.5;
+            Transform::from_row(scale, 0.0, 0.0, scale, offset_x, offset_y)
+        }
+    };
+
+    resvg::render(tree, transform, &mut pixmap.as_mut());
+
+    let pixels = pixmap
+        .pixels()
+        .iter()
+        .map(|pixel| {
+            let color = pixel.demultiply();
+            RgbaColor {
+                r: color.red() as f32 / 255.0,
+                g: color.green() as f32 / 255.0,
+                b: color.blue() as f32 / 255.0,
+                a: color.alpha() as f32 / 255.0,
+            }
+        })
+        .collect();
+
+    Ok(ColorFrame {
+        layout: layout.clone(),
+        pixels,
+    })
+}
+
+fn render_dimensions(layout: &LedLayout) -> (usize, usize) {
+    match (layout.width, layout.height) {
+        (Some(width), Some(height)) if width > 1 && height > 1 => (width, height),
+        _ => (layout.pixel_count.max(1), 1),
+    }
+}
+
+fn sample_source_image(
+    source_image: &RgbaImage,
+    x: usize,
+    y: usize,
+    target_width: usize,
+    target_height: usize,
+    fit_mode: ImageFitMode,
+) -> RgbaColor {
+    let source_width = source_image.width() as f32;
+    let source_height = source_image.height() as f32;
+    let target_width = target_width as f32;
+    let target_height = target_height as f32;
+    let target_x = x as f32 + 0.5;
+    let target_y = y as f32 + 0.5;
+
+    let (source_x, source_y) = match fit_mode {
+        ImageFitMode::Stretch => (
+            target_x / target_width * source_width,
+            target_y / target_height * source_height,
+        ),
+        ImageFitMode::Contain | ImageFitMode::Cover => {
+            let scale_x = target_width / source_width;
+            let scale_y = target_height / source_height;
+            let scale = match fit_mode {
+                ImageFitMode::Contain => scale_x.min(scale_y),
+                ImageFitMode::Cover => scale_x.max(scale_y),
+                ImageFitMode::Stretch => unreachable!(),
+            };
+
+            let rendered_width = source_width * scale;
+            let rendered_height = source_height * scale;
+            let offset_x = (target_width - rendered_width) * 0.5;
+            let offset_y = (target_height - rendered_height) * 0.5;
+            let local_x = target_x - offset_x;
+            let local_y = target_y - offset_y;
+
+            if matches!(fit_mode, ImageFitMode::Contain)
+                && (local_x < 0.0
+                    || local_y < 0.0
+                    || local_x >= rendered_width
+                    || local_y >= rendered_height)
+            {
+                return transparent_black();
+            }
+
+            (local_x / scale, local_y / scale)
+        }
+    };
+
+    rgba_from_image_pixel(source_image, source_x, source_y)
+}
+
+fn rgba_from_image_pixel(source_image: &RgbaImage, source_x: f32, source_y: f32) -> RgbaColor {
+    let max_x = source_image.width().saturating_sub(1) as f32;
+    let max_y = source_image.height().saturating_sub(1) as f32;
+    let pixel = source_image.get_pixel(
+        source_x.floor().clamp(0.0, max_x) as u32,
+        source_y.floor().clamp(0.0, max_y) as u32,
+    );
+    RgbaColor {
+        r: pixel[0] as f32 / 255.0,
+        g: pixel[1] as f32 / 255.0,
+        b: pixel[2] as f32 / 255.0,
+        a: pixel[3] as f32 / 255.0,
+    }
+}
+
+fn transparent_black() -> RgbaColor {
+    RgbaColor {
+        r: 0.0,
+        g: 0.0,
+        b: 0.0,
+        a: 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+    use image::Rgba;
+    use shared::LedLayout;
+    use std::io::ErrorKind;
+    use std::time::{Duration, Instant};
+
+    use super::{
+        DecodedSource, ImageFitMode, ImageSourceNode, decode_image_source, render_image_to_frame,
+        render_source_to_frame, target_layout, transparent_black, user_facing_load_error_message,
+    };
+    use crate::node_runtime::{NodeEvaluationContext, RuntimeNode};
+
+    fn sample_image() -> image::RgbaImage {
+        image::RgbaImage::from_fn(2, 1, |x, _| match x {
+            0 => Rgba([255, 0, 0, 255]),
+            _ => Rgba([0, 0, 255, 255]),
+        })
+    }
+
+    #[test]
+    fn uses_source_dimensions_when_no_render_layout_is_available() {
+        let layout = target_layout(None, &DecodedSource::Raster(sample_image()));
+
+        assert_eq!(layout.pixel_count, 2);
+        assert_eq!(layout.width, Some(2));
+        assert_eq!(layout.height, Some(1));
+    }
+
+    #[test]
+    fn contain_mode_letterboxes_when_target_is_taller_than_source() {
+        let image = sample_image();
+        let frame = render_image_to_frame(
+            &image,
+            &LedLayout {
+                id: "matrix".to_owned(),
+                pixel_count: 4,
+                width: Some(2),
+                height: Some(2),
+            },
+            ImageFitMode::Contain,
+        );
+
+        assert_eq!(frame.pixels[0].r, 1.0);
+        assert_eq!(frame.pixels[1].b, 1.0);
+        assert_eq!(frame.pixels[2], transparent_black());
+        assert_eq!(frame.pixels[3], transparent_black());
+    }
+
+    #[test]
+    fn svg_payload_uses_svg_dimensions_when_no_render_layout_is_available() {
+        let source = decode_image_source(
+            br##"<svg xmlns="http://www.w3.org/2000/svg" width="4" height="3"><rect width="4" height="3" fill="#ff0000"/></svg>"##,
+            Some("image/svg+xml"),
+        )
+        .expect("svg should parse");
+        let layout = target_layout(None, &source);
+
+        assert_eq!(layout.pixel_count, 12);
+        assert_eq!(layout.width, Some(4));
+        assert_eq!(layout.height, Some(3));
+    }
+
+    #[test]
+    fn missing_uploaded_image_produces_warning_diagnostic() {
+        let mut node = ImageSourceNode {
+            ..Default::default()
+        };
+
+        let evaluation = node
+            .evaluate(
+                &NodeEvaluationContext {
+                    graph_id: "graph".to_owned(),
+                    graph_name: "Graph".to_owned(),
+                    elapsed_seconds: 0.0,
+                    render_layout: None,
+                },
+                (),
+            )
+            .expect("missing upload should not panic");
+
+        assert!(evaluation.outputs.frame.pixels.is_empty());
+        assert_eq!(evaluation.diagnostics.len(), 1);
+        assert_eq!(
+            evaluation.diagnostics[0].code.as_deref(),
+            Some("image_source_missing_source")
+        );
+    }
+
+    #[test]
+    fn renders_svg_payload_into_target_layout() {
+        let source = decode_image_source(
+            br##"<svg xmlns="http://www.w3.org/2000/svg" width="2" height="1"><rect width="1" height="1" fill="#ff0000"/><rect x="1" width="1" height="1" fill="#0000ff"/></svg>"##,
+            Some("image/svg+xml"),
+        )
+        .expect("svg should parse");
+
+        let frame = render_source_to_frame(
+            &source,
+            &LedLayout {
+                id: "matrix".to_owned(),
+                pixel_count: 2,
+                width: Some(2),
+                height: Some(1),
+            },
+            ImageFitMode::Stretch,
+        )
+        .expect("svg should render");
+
+        assert!(frame.pixels[0].r > 0.9);
+        assert!(frame.pixels[1].b > 0.9);
+    }
+
+    #[test]
+    fn missing_uploaded_image_uses_sanitized_diagnostic_message() {
+        let error = std::fs::read("definitely-missing-image-asset")
+            .context("read image asset")
+            .context("Load uploaded image asset")
+            .expect_err("missing file should error");
+
+        let message = user_facing_load_error_message("asset-123", &error);
+
+        assert_eq!(message, "Uploaded image asset 'asset-123' is missing.");
+        assert!(matches!(
+            error.downcast_ref::<std::io::Error>().map(std::io::Error::kind),
+            Some(ErrorKind::NotFound)
+        ));
+    }
+
+    #[test]
+    fn cached_failure_is_only_marked_for_logging_once() {
+        let mut node = ImageSourceNode {
+            cached_source: Some(super::CachedImageSource::Failed {
+                asset_id: "asset-123".to_owned(),
+                message: "missing".to_owned(),
+                retry_after: Instant::now() + Duration::from_secs(5),
+                warning_emitted: false,
+            }),
+            ..Default::default()
+        };
+
+        assert!(node.mark_failure_logged("asset-123"));
+        assert!(!node.mark_failure_logged("asset-123"));
+        assert!(!node.mark_failure_logged("other-asset"));
+    }
+}

--- a/crates/backend/src/node_runtime/nodes/inputs/mod.rs
+++ b/crates/backend/src/node_runtime/nodes/inputs/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod color_constant;
 pub(crate) mod float_constant;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod ha_mqtt_number;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod image_source;
 pub(crate) mod signal_generator;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod wled_sink;

--- a/crates/backend/src/node_runtime/registry.rs
+++ b/crates/backend/src/node_runtime/registry.rs
@@ -184,6 +184,10 @@ fn build_registry(target: NodeExecutionTarget) -> anyhow::Result<Arc<NodeRegistr
             nodes::inputs::audio_fft_receiver::AudioFftReceiverNode
         );
         register_builtin!(
+            NodeTypeId::IMAGE_SOURCE,
+            nodes::inputs::image_source::ImageSourceNode
+        );
+        register_builtin!(
             NodeTypeId::HA_MQTT_NUMBER,
             nodes::inputs::ha_mqtt_number::HomeAssistantMqttNumberNode
         );

--- a/crates/backend/src/services/image_asset_store.rs
+++ b/crates/backend/src/services/image_asset_store.rs
@@ -1,0 +1,152 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use anyhow::Context;
+use uuid::Uuid;
+
+use crate::services::image_codec::{is_svg_payload, parse_svg};
+
+static GLOBAL_IMAGE_ASSET_STORE: OnceLock<Arc<ImageAssetStore>> = OnceLock::new();
+
+/// Registers the global image asset store used by runtime nodes.
+pub(crate) fn set_global_image_asset_store(store: Arc<ImageAssetStore>) -> anyhow::Result<()> {
+    GLOBAL_IMAGE_ASSET_STORE
+        .set(store)
+        .map_err(|_| anyhow::anyhow!("global image asset store already initialized"))
+}
+
+/// Returns the process-wide image asset store when backend startup initialized it.
+pub(crate) fn global_image_asset_store() -> Option<&'static Arc<ImageAssetStore>> {
+    GLOBAL_IMAGE_ASSET_STORE.get()
+}
+
+/// Persists uploaded image bytes so graph nodes can reference them by stable asset id.
+pub(crate) struct ImageAssetStore {
+    asset_dir: PathBuf,
+}
+
+impl ImageAssetStore {
+    /// Creates the asset store rooted under the backend data directory.
+    pub(crate) fn new(data_dir: &Path) -> anyhow::Result<Self> {
+        let asset_dir = data_dir.join("assets").join("images");
+        fs::create_dir_all(&asset_dir)
+            .with_context(|| format!("create image asset directory {}", asset_dir.display()))?;
+        Ok(Self { asset_dir })
+    }
+
+    /// Validates and stores uploaded image bytes, returning the new asset id.
+    pub(crate) fn store_image_bytes(&self, bytes: &[u8]) -> anyhow::Result<String> {
+        anyhow::ensure!(!bytes.is_empty(), "uploaded image is empty");
+        validate_uploaded_image(bytes)?;
+
+        let asset_id = Uuid::new_v4().to_string();
+        let path = self.asset_path(&asset_id)?;
+        fs::write(&path, bytes)
+            .with_context(|| format!("write uploaded image asset {}", path.display()))?;
+        Ok(asset_id)
+    }
+
+    /// Loads the original bytes for a previously uploaded image asset.
+    pub(crate) fn load_image_bytes(&self, asset_id: &str) -> anyhow::Result<Vec<u8>> {
+        let path = self.asset_path(asset_id)?;
+        fs::read(&path).with_context(|| format!("read image asset {}", path.display()))
+    }
+
+    fn asset_path(&self, asset_id: &str) -> anyhow::Result<PathBuf> {
+        let parsed = Uuid::parse_str(asset_id)
+            .with_context(|| format!("image asset id '{asset_id}' is invalid"))?;
+        Ok(self.asset_dir.join(parsed.to_string()))
+    }
+}
+
+fn validate_uploaded_image(bytes: &[u8]) -> anyhow::Result<()> {
+    if is_svg_payload(bytes) {
+        parse_svg(bytes, "decode uploaded image")?;
+        return Ok(());
+    }
+
+    image::load_from_memory(bytes).context("decode uploaded image")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use image::{DynamicImage, ImageFormat, RgbaImage};
+
+    use super::ImageAssetStore;
+
+    fn temp_test_dir(test_name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("luma-weaver-{test_name}-{}", uuid::Uuid::new_v4()))
+    }
+
+    fn sample_png_bytes() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let image = DynamicImage::ImageRgba8(
+            RgbaImage::from_vec(
+                2,
+                1,
+                vec![
+                    255, 0, 0, 255, //
+                    0, 0, 255, 255,
+                ],
+            )
+            .expect("construct test image"),
+        );
+        image
+            .write_to(&mut std::io::Cursor::new(&mut bytes), ImageFormat::Png)
+            .expect("encode png");
+        bytes
+    }
+
+    #[test]
+    fn stores_and_loads_uploaded_image_bytes() {
+        let data_dir = temp_test_dir("stores-and-loads-uploaded-image-bytes");
+        let store = ImageAssetStore::new(&data_dir).expect("create image asset store");
+        let bytes = sample_png_bytes();
+
+        let asset_id = store.store_image_bytes(&bytes).expect("store image asset");
+        let loaded = store
+            .load_image_bytes(&asset_id)
+            .expect("load stored image asset");
+
+        assert_eq!(loaded, bytes);
+
+        let _ = fs::remove_dir_all(data_dir);
+    }
+
+    #[test]
+    fn rejects_invalid_uploaded_image_bytes() {
+        let data_dir = temp_test_dir("rejects-invalid-uploaded-image-bytes");
+        let store = ImageAssetStore::new(&data_dir).expect("create image asset store");
+
+        let error = store
+            .store_image_bytes(b"not an image")
+            .expect_err("invalid image bytes should fail");
+
+        assert!(error.to_string().contains("decode uploaded image"));
+
+        let _ = fs::remove_dir_all(data_dir);
+    }
+
+    #[test]
+    fn accepts_uploaded_svg_bytes() {
+        let data_dir = temp_test_dir("accepts-uploaded-svg-bytes");
+        let store = ImageAssetStore::new(&data_dir).expect("create image asset store");
+
+        let asset_id = store
+            .store_image_bytes(
+                br##"<svg xmlns="http://www.w3.org/2000/svg" width="2" height="1"><rect width="2" height="1" fill="#ff0000"/></svg>"##,
+            )
+            .expect("store svg image asset");
+
+        let loaded = store
+            .load_image_bytes(&asset_id)
+            .expect("load stored image asset");
+        assert!(!loaded.is_empty());
+
+        let _ = fs::remove_dir_all(data_dir);
+    }
+}

--- a/crates/backend/src/services/image_codec.rs
+++ b/crates/backend/src/services/image_codec.rs
@@ -1,0 +1,17 @@
+use anyhow::Context;
+use resvg::usvg::{Options, Tree};
+
+pub(crate) fn is_svg_payload(bytes: &[u8]) -> bool {
+    let sniff_len = bytes.len().min(512);
+    let prefix = String::from_utf8_lossy(&bytes[..sniff_len]).to_lowercase();
+    let trimmed = prefix.trim_start_matches(|ch: char| ch.is_whitespace() || ch == '\u{feff}');
+    trimmed.starts_with("<svg")
+        || (trimmed.starts_with("<?xml") && trimmed.contains("<svg"))
+        || trimmed.contains("<svg")
+}
+
+pub(crate) fn parse_svg(bytes: &[u8], context: &str) -> anyhow::Result<Tree> {
+    let mut options = Options::default();
+    options.fontdb_mut().load_system_fonts();
+    Tree::from_data(bytes, &options).with_context(|| context.to_owned())
+}

--- a/crates/backend/src/services/mod.rs
+++ b/crates/backend/src/services/mod.rs
@@ -1,6 +1,12 @@
 /// Persistent graph document storage and import/export helpers.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod graph_store;
+/// Persistent storage for uploaded image assets used by graph nodes.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod image_asset_store;
+/// Shared image decoding helpers used by uploads and runtime nodes.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod image_codec;
 /// Home Assistant MQTT discovery, broker tasks, and entity synchronization.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod mqtt;

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -18,6 +18,7 @@ egui.workspace = true
 egui-snarl = "0.9"
 futures-channel.workspace = true
 futures-util.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 shared = { path = "../shared" }
 tracing.workspace = true
@@ -29,4 +30,4 @@ js-sys = "0.3"
 tracing-wasm.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures = "0.4"
-web-sys = { workspace = true, features = ["Blob", "Document", "Event", "File", "FileList", "FileReader", "History", "HtmlAnchorElement", "HtmlCanvasElement", "HtmlInputElement", "Location", "Url", "Window"] }
+web-sys = { workspace = true, features = ["Blob", "Document", "Event", "File", "FileList", "FileReader", "Headers", "History", "HtmlAnchorElement", "HtmlCanvasElement", "HtmlInputElement", "Location", "Request", "RequestInit", "Response", "Url", "Window"] }

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -1,5 +1,6 @@
 mod graph_actions;
 mod history;
+mod image_assets;
 mod import_export;
 mod messaging;
 mod navigation;
@@ -46,6 +47,7 @@ impl eframe::App for FrontendApp {
         self.ensure_runtime_updates_subscription();
         self.drain_server_messages(ctx);
         self.drain_browser_graph_file_events();
+        self.drain_browser_image_asset_events();
         crate::header_view::render(ctx, self);
 
         egui::CentralPanel::default().show(ctx, |ui| match self.ui.active_view {
@@ -56,7 +58,7 @@ impl eframe::App for FrontendApp {
         self.handle_history_shortcuts(ctx);
         self.schedule_graph_document_update(ctx);
 
-        if self.demo_runtime_needs_repaint() {
+        if self.demo_runtime_needs_repaint() || self.browser_background_work_needs_repaint() {
             ctx.request_repaint_after(Duration::from_millis(16));
         }
     }

--- a/crates/frontend/src/app/image_assets.rs
+++ b/crates/frontend/src/app/image_assets.rs
@@ -1,0 +1,117 @@
+use serde_json::Value as JsonValue;
+
+use super::FrontendApp;
+
+impl FrontendApp {
+    /// Starts the browser flow for selecting and uploading an image asset for a node parameter.
+    pub(crate) fn begin_image_asset_upload(&mut self, node_id: String, parameter_name: String) {
+        match crate::browser_file::pick_and_upload_image_asset(node_id, parameter_name) {
+            Ok(receiver) => {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    self.ui.browser_image_asset_events = Some(receiver);
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let _ = receiver;
+                }
+                self.ui.status = "Choose an image to upload".to_owned();
+            }
+            Err(message) => {
+                self.ui.status = message;
+            }
+        }
+    }
+
+    /// Drains pending browser image-upload events and applies successful asset ids into the graph.
+    pub(super) fn drain_browser_image_asset_events(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            return;
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            use futures_channel::mpsc::TryRecvError;
+
+            let Some(receiver) = &mut self.ui.browser_image_asset_events else {
+                return;
+            };
+
+            let mut events = Vec::new();
+            let mut receiver_closed = false;
+            loop {
+                match receiver.try_recv() {
+                    Ok(event) => events.push(event),
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Closed) => {
+                        receiver_closed = true;
+                        break;
+                    }
+                }
+            }
+
+            if !events.is_empty() || receiver_closed {
+                self.ui.browser_image_asset_events = None;
+            }
+
+            for event in events {
+                match event {
+                    crate::browser_file::BrowserImageAssetEvent::Uploaded {
+                        node_id,
+                        parameter_name,
+                        asset_id,
+                    } => self.apply_uploaded_image_asset(node_id, parameter_name, asset_id),
+                    crate::browser_file::BrowserImageAssetEvent::Error(message) => {
+                        self.ui.status = message;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns whether browser-managed background work should keep scheduling frames.
+    pub(crate) fn browser_background_work_needs_repaint(&self) -> bool {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            false
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.ui.browser_graph_file_events.is_some()
+                || self.ui.browser_image_asset_events.is_some()
+        }
+    }
+
+    fn apply_uploaded_image_asset(
+        &mut self,
+        node_id: String,
+        parameter_name: String,
+        asset_id: String,
+    ) {
+        let Some(document) = self.active_graph_document_mut() else {
+            self.ui.status = "Cannot apply uploaded image without an open graph".to_owned();
+            return;
+        };
+        let Some(node) = document.nodes.iter_mut().find(|node| node.id == node_id) else {
+            self.ui.status = "The edited node no longer exists in the open graph".to_owned();
+            return;
+        };
+
+        if let Some(parameter) = node
+            .parameters
+            .iter_mut()
+            .find(|parameter| parameter.name == parameter_name)
+        {
+            parameter.value = JsonValue::from(asset_id.clone());
+        } else {
+            node.parameters.push(shared::NodeParameter {
+                name: parameter_name,
+                value: JsonValue::from(asset_id.clone()),
+            });
+        }
+
+        self.ui.status = "Uploaded image asset".to_owned();
+    }
+}

--- a/crates/frontend/src/browser_file.rs
+++ b/crates/frontend/src/browser_file.rs
@@ -7,6 +7,16 @@ pub(crate) enum BrowserGraphFileEvent {
     Error(String),
 }
 
+/// Represents the outcome of a browser-managed image upload.
+pub(crate) enum BrowserImageAssetEvent {
+    Uploaded {
+        node_id: String,
+        parameter_name: String,
+        asset_id: String,
+    },
+    Error(String),
+}
+
 #[cfg(target_arch = "wasm32")]
 /// Opens the browser file picker for graph import and returns a stream of parse results.
 ///
@@ -152,4 +162,163 @@ pub(crate) fn download_graph_export(
     _file: &GraphExchangeFile,
 ) -> Result<(), String> {
     Err("Graph export is only available in the browser build".to_owned())
+}
+
+#[cfg(target_arch = "wasm32")]
+/// Opens the browser file picker for an image upload and returns a stream of upload results.
+pub(crate) fn pick_and_upload_image_asset(
+    node_id: String,
+    parameter_name: String,
+) -> Result<mpsc::UnboundedReceiver<BrowserImageAssetEvent>, String> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen::closure::Closure;
+
+    let Some(window) = web_sys::window() else {
+        return Err("Browser window is unavailable".to_owned());
+    };
+    let Some(document) = window.document() else {
+        return Err("Browser document is unavailable".to_owned());
+    };
+    let input = document
+        .create_element("input")
+        .map_err(|_| "Failed to create file input".to_owned())?
+        .dyn_into::<web_sys::HtmlInputElement>()
+        .map_err(|_| "Failed to create file input".to_owned())?;
+    input.set_type("file");
+    input.set_accept("image/*");
+
+    let (sender, receiver) = mpsc::unbounded();
+    let onchange_sender = sender.clone();
+    let onchange_input = input.clone();
+    let onchange = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+        let Some(files) = onchange_input.files() else {
+            let _ = onchange_sender.unbounded_send(BrowserImageAssetEvent::Error(
+                "No file was selected".to_owned(),
+            ));
+            return;
+        };
+        let Some(file) = files.get(0) else {
+            let _ = onchange_sender.unbounded_send(BrowserImageAssetEvent::Error(
+                "No file was selected".to_owned(),
+            ));
+            return;
+        };
+
+        let Ok(reader) = web_sys::FileReader::new() else {
+            let _ = onchange_sender.unbounded_send(BrowserImageAssetEvent::Error(
+                "Failed to create browser file reader".to_owned(),
+            ));
+            return;
+        };
+
+        let load_sender = onchange_sender.clone();
+        let load_reader = reader.clone();
+        let upload_node_id = node_id.clone();
+        let upload_parameter_name = parameter_name.clone();
+        let onload = Closure::once(Box::new(move |_event: web_sys::Event| {
+            let Some(result) = load_reader.result().ok() else {
+                let _ = load_sender.unbounded_send(BrowserImageAssetEvent::Error(
+                    "Failed to read image file".to_owned(),
+                ));
+                return;
+            };
+            let array = js_sys::Uint8Array::new(&result);
+            let bytes = array.to_vec();
+            let upload_sender = load_sender.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let event = match upload_image_asset(bytes).await {
+                    Ok(asset_id) => BrowserImageAssetEvent::Uploaded {
+                        node_id: upload_node_id,
+                        parameter_name: upload_parameter_name,
+                        asset_id,
+                    },
+                    Err(message) => BrowserImageAssetEvent::Error(message),
+                };
+                let _ = upload_sender.unbounded_send(event);
+            });
+        }) as Box<dyn FnOnce(_)>);
+        reader.set_onload(Some(onload.as_ref().unchecked_ref()));
+        onload.forget();
+
+        let error_sender = onchange_sender.clone();
+        let onerror = Closure::once(Box::new(move |_event: web_sys::Event| {
+            let _ = error_sender.unbounded_send(BrowserImageAssetEvent::Error(
+                "Failed to read image file".to_owned(),
+            ));
+        }) as Box<dyn FnOnce(_)>);
+        reader.set_onerror(Some(onerror.as_ref().unchecked_ref()));
+        onerror.forget();
+
+        if reader.read_as_array_buffer(&file).is_err() {
+            let _ = onchange_sender.unbounded_send(BrowserImageAssetEvent::Error(
+                "Failed to start reading image file".to_owned(),
+            ));
+        }
+    }) as Box<dyn FnMut(_)>);
+
+    input.set_onchange(Some(onchange.as_ref().unchecked_ref()));
+    onchange.forget();
+    input.click();
+
+    Ok(receiver)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn upload_image_asset(bytes: Vec<u8>) -> Result<String, String> {
+    use serde::Deserialize;
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+
+    #[derive(Deserialize)]
+    struct UploadImageAssetResponse {
+        asset_id: String,
+    }
+
+    let init = web_sys::RequestInit::new();
+    init.set_method("POST");
+    init.set_body(&js_sys::Uint8Array::from(bytes.as_slice()).into());
+
+    let request = web_sys::Request::new_with_str_and_init("/api/assets/images", &init)
+        .map_err(|_| "Failed to build upload request".to_owned())?;
+
+    let Some(window) = web_sys::window() else {
+        return Err("Browser window is unavailable".to_owned());
+    };
+    let response_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|_| "Image upload request failed".to_owned())?;
+    let response = response_value
+        .dyn_into::<web_sys::Response>()
+        .map_err(|_| "Image upload response was invalid".to_owned())?;
+    let response_text = JsFuture::from(
+        response
+            .text()
+            .map_err(|_| "Failed to read image upload response".to_owned())?,
+    )
+    .await
+    .map_err(|_| "Failed to read image upload response".to_owned())?
+    .as_string()
+    .unwrap_or_default();
+
+    if !response.ok() {
+        let fallback = format!("Image upload failed with status {}", response.status());
+        return Err(if response_text.trim().is_empty() {
+            fallback
+        } else {
+            response_text
+        });
+    }
+
+    serde_json::from_str::<UploadImageAssetResponse>(&response_text)
+        .map(|response| response.asset_id)
+        .map_err(|error| format!("Failed to parse image upload response: {error}"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Reports that image uploads via the browser file picker are unavailable on non-wasm builds.
+pub(crate) fn pick_and_upload_image_asset(
+    _node_id: String,
+    _parameter_name: String,
+) -> Result<mpsc::UnboundedReceiver<BrowserImageAssetEvent>, String> {
+    Err("Image uploads are only available in the browser build".to_owned())
 }

--- a/crates/frontend/src/editor_view.rs
+++ b/crates/frontend/src/editor_view.rs
@@ -186,6 +186,7 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                 .ui
                 .node_menu_graph_position
                 .map(|(x, y)| egui::pos2(x, y));
+            let mut requested_image_upload = None;
             if let Some(document) = app.active_graph_document_mut() {
                 if available_node_definitions.is_empty() {
                     egui::Frame::group(ui.style()).show(ui, |ui| {
@@ -204,6 +205,7 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                     canvas_hovered,
                     node_menu_search,
                     node_menu_graph_position,
+                    image_upload_request,
                 ) = viewer::show_snarl_canvas(
                     ui,
                     document,
@@ -226,6 +228,7 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                 if let Some(node_id) = opened_diagnostics_node_id {
                     app.open_node_diagnostics(node_id);
                 }
+                requested_image_upload = image_upload_request;
             } else {
                 egui::Frame::group(ui.style()).show(ui, |ui| {
                     ui.set_min_height(100.0);
@@ -238,6 +241,9 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
             }
             if initialized_viewport_for_graph {
                 app.graphs.snarl_viewport_initialized_graph_id = Some(graph.id.clone());
+            }
+            if let Some((node_id, parameter_name)) = requested_image_upload {
+                app.begin_image_asset_upload(node_id, parameter_name);
             }
 
             crate::diagnostics_view::render_node_diagnostics_window(ui.ctx(), app);

--- a/crates/frontend/src/editor_view/viewer.rs
+++ b/crates/frontend/src/editor_view/viewer.rs
@@ -27,6 +27,7 @@ struct GraphSnarlViewer {
     plot_history: std::collections::HashMap<String, Vec<f32>>,
     diagnostic_summaries: std::collections::HashMap<String, NodeDiagnosticSummary>,
     opened_diagnostics_node_id: Option<String>,
+    requested_image_upload: Option<(String, String)>,
     node_menu_search: String,
     requested_graph_menu_pos: Option<egui::Pos2>,
 }
@@ -260,7 +261,7 @@ impl SnarlViewer<EditorSnarlNode> for GraphSnarlViewer {
                 .show(ui, |ui| {
                     for parameter_definition in &visible_parameters {
                         ui.label(&parameter_definition.display_name);
-                        edit_parameter_value(
+                        let requested_upload = edit_parameter_value(
                             ui,
                             &mut editor_node.parameters,
                             &parameter_definition.name,
@@ -269,6 +270,12 @@ impl SnarlViewer<EditorSnarlNode> for GraphSnarlViewer {
                             &self.wled_instances,
                             &self.mqtt_broker_configs,
                         );
+                        if requested_upload {
+                            self.requested_image_upload = Some((
+                                editor_node.graph_node_id.clone(),
+                                parameter_definition.name.clone(),
+                            ));
+                        }
                         ui.end_row();
                     }
                 });
@@ -438,7 +445,8 @@ fn render_graph_menu_contents(
 /// Renders the graph canvas, synchronizes it with the document model, and returns UI side effects.
 ///
 /// The returned tuple carries viewport-application state, diagnostics-panel requests, hover state,
-/// node-menu search text, and the next graph-space position for the add-node menu.
+/// node-menu search text, the next graph-space position for the add-node menu, and any requested
+/// image upload action.
 pub(super) fn show_snarl_canvas(
     ui: &mut egui::Ui,
     document: &mut GraphDocument,
@@ -455,7 +463,14 @@ pub(super) fn show_snarl_canvas(
     node_menu_graph_position: Option<egui::Pos2>,
     apply_document_viewport: bool,
     focus_requested: bool,
-) -> (bool, Option<String>, bool, String, Option<egui::Pos2>) {
+) -> (
+    bool,
+    Option<String>,
+    bool,
+    String,
+    Option<egui::Pos2>,
+    Option<(String, String)>,
+) {
     let canvas_size = ui.available_size();
     if focus_requested {
         center_viewport_on_nodes(document, canvas_size);
@@ -484,6 +499,7 @@ pub(super) fn show_snarl_canvas(
             .collect(),
         diagnostic_summaries: diagnostic_summaries.clone(),
         opened_diagnostics_node_id: None,
+        requested_image_upload: None,
         node_menu_search: node_menu_search.to_owned(),
         requested_graph_menu_pos: None,
     };
@@ -544,6 +560,7 @@ pub(super) fn show_snarl_canvas(
         canvas_hovered,
         viewer.node_menu_search,
         next_node_menu_graph_position,
+        viewer.requested_image_upload,
     )
 }
 

--- a/crates/frontend/src/editor_view/widgets.rs
+++ b/crates/frontend/src/editor_view/widgets.rs
@@ -290,7 +290,7 @@ pub(super) fn edit_parameter_value(
     default_value: JsonValue,
     wled_instances: &[WledInstance],
     mqtt_broker_configs: &[MqttBrokerConfig],
-) {
+) -> bool {
     let value = parameter_value_mut(parameters, name, default_value);
     match ui_hint {
         ParameterUiHint::DragFloat { speed, min, max } => {
@@ -305,6 +305,7 @@ pub(super) fn edit_parameter_value(
             {
                 *value = JsonValue::from(float_value);
             }
+            false
         }
         ParameterUiHint::ColorPicker => {
             let mut color =
@@ -322,18 +323,21 @@ pub(super) fn edit_parameter_value(
                 color.a = rgba[3];
                 *value = serde_json::to_value(color).unwrap_or(JsonValue::Null);
             }
+            false
         }
         ParameterUiHint::ColorGradient => {
             let mut gradient = serde_json::from_value::<ColorGradient>(value.clone())
                 .unwrap_or_else(|_| default_editor_gradient());
             edit_color_gradient_button(ui, name, &mut gradient);
             *value = serde_json::to_value(normalize_gradient(gradient)).unwrap_or(JsonValue::Null);
+            false
         }
         ParameterUiHint::Checkbox => {
             let mut bool_value = value.as_bool().unwrap_or(false);
             if ui.checkbox(&mut bool_value, "").changed() {
                 *value = JsonValue::from(bool_value);
             }
+            false
         }
         ParameterUiHint::TextSingleLine => {
             let mut text = value.as_str().unwrap_or("").to_owned();
@@ -346,6 +350,36 @@ pub(super) fn edit_parameter_value(
             {
                 *value = JsonValue::from(text);
             }
+            false
+        }
+        ParameterUiHint::ImageAssetUpload => {
+            let asset_id = value.as_str().unwrap_or("").to_owned();
+            let mut requested_upload = false;
+            ui.horizontal(|ui| {
+                let label = if asset_id.trim().is_empty() {
+                    "No image uploaded".to_owned()
+                } else {
+                    format!("{}", shorten_asset_id(&asset_id))
+                };
+                let response = ui.label(label);
+                if !asset_id.trim().is_empty() {
+                    response.on_hover_text(asset_id.clone());
+                }
+                if ui
+                    .small_button(if asset_id.trim().is_empty() {
+                        "Upload"
+                    } else {
+                        "Replace"
+                    })
+                    .clicked()
+                {
+                    requested_upload = true;
+                }
+                if !asset_id.trim().is_empty() && ui.small_button("Clear").clicked() {
+                    *value = JsonValue::from(String::new());
+                }
+            });
+            requested_upload
         }
         ParameterUiHint::EnumSelect { options } => {
             let mut selected = value.as_str().unwrap_or("").to_owned();
@@ -377,6 +411,7 @@ pub(super) fn edit_parameter_value(
                 }
             }
             *value = JsonValue::from(selected);
+            false
         }
         ParameterUiHint::IntegerDrag { speed, min, max } => {
             let mut int_value = value.as_i64().unwrap_or(0);
@@ -390,6 +425,7 @@ pub(super) fn edit_parameter_value(
             {
                 *value = JsonValue::from(int_value);
             }
+            false
         }
         ParameterUiHint::WledInstanceOrHost => {
             let mut target = value.as_str().unwrap_or("").to_owned();
@@ -430,6 +466,7 @@ pub(super) fn edit_parameter_value(
                 *parameter_value_mut(parameters, "led_count", JsonValue::from(led_count as i64)) =
                     JsonValue::from(led_count as i64);
             }
+            false
         }
         ParameterUiHint::MqttBrokerSelect => {
             let mut selected = value.as_str().unwrap_or("").to_owned();
@@ -475,7 +512,16 @@ pub(super) fn edit_parameter_value(
                     }
                 });
             *value = JsonValue::from(selected);
+            false
         }
+    }
+}
+
+fn shorten_asset_id(asset_id: &str) -> String {
+    if asset_id.len() <= 12 {
+        asset_id.to_owned()
+    } else {
+        format!("{}...", &asset_id[..12])
     }
 }
 

--- a/crates/frontend/src/state.rs
+++ b/crates/frontend/src/state.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use eframe::egui;
+#[cfg(target_arch = "wasm32")]
 use futures_channel::mpsc;
 use shared::{
     EventSubscription, GraphDocument, GraphExchangeFile, GraphMetadata, GraphRuntimeMode,
@@ -40,6 +41,9 @@ pub(crate) struct UiState {
     #[cfg(target_arch = "wasm32")]
     pub(crate) browser_graph_file_events:
         Option<mpsc::UnboundedReceiver<crate::browser_file::BrowserGraphFileEvent>>,
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) browser_image_asset_events:
+        Option<mpsc::UnboundedReceiver<crate::browser_file::BrowserImageAssetEvent>>,
 }
 
 impl Default for UiState {
@@ -66,6 +70,8 @@ impl Default for UiState {
             pending_import_graph_file: None,
             #[cfg(target_arch = "wasm32")]
             browser_graph_file_events: None,
+            #[cfg(target_arch = "wasm32")]
+            browser_image_asset_events: None,
         }
     }
 }

--- a/crates/shared/src/graph/builtin_nodes.rs
+++ b/crates/shared/src/graph/builtin_nodes.rs
@@ -94,6 +94,23 @@ static AUDIO_FFT_RECEIVE_MODES: LazyLock<Vec<EnumOption>> = LazyLock::new(|| {
     ]
 });
 
+static IMAGE_FIT_MODES: LazyLock<Vec<EnumOption>> = LazyLock::new(|| {
+    vec![
+        EnumOption {
+            value: "stretch".to_owned(),
+            label: "Stretch".to_owned(),
+        },
+        EnumOption {
+            value: "contain".to_owned(),
+            label: "Contain".to_owned(),
+        },
+        EnumOption {
+            value: "cover".to_owned(),
+            label: "Cover".to_owned(),
+        },
+    ]
+});
+
 static MIN_MAX_FLOAT_MODES: LazyLock<Vec<EnumOption>> = LazyLock::new(|| {
     vec![
         EnumOption {
@@ -176,6 +193,41 @@ static COLOR_CONSTANT_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| Nod
         }),
         ParameterUiHint::ColorPicker,
     )],
+    connection: NodeConnectionDefinition {
+        max_input_connections: 1,
+        require_value_kind_match: true,
+    },
+    runtime_updates: None,
+});
+
+static IMAGE_SOURCE_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
+    id: NodeTypeId::IMAGE_SOURCE.to_owned(),
+    display_name: "Image Source".to_owned(),
+    category: NodeCategory::Inputs,
+    needs_io: true,
+    inputs: vec![],
+    outputs: vec![NodeOutputDefinition {
+        name: "frame".to_owned(),
+        display_name: title_case_name("frame"),
+        value_kind: ValueKind::ColorFrame,
+        accepted_kinds: vec![],
+    }],
+    parameters: vec![
+        NodeParameterDefinition::new(
+            "asset_id",
+            title_case_name("asset_id"),
+            ParameterDefaultValue::String(String::new()),
+            ParameterUiHint::ImageAssetUpload,
+        ),
+        NodeParameterDefinition::new(
+            "fit_mode",
+            title_case_name("fit_mode"),
+            ParameterDefaultValue::String("contain".to_owned()),
+            ParameterUiHint::EnumSelect {
+                options: IMAGE_FIT_MODES.clone(),
+            },
+        ),
+    ],
     connection: NodeConnectionDefinition {
         max_input_connections: 1,
         require_value_kind_match: true,
@@ -2084,6 +2136,7 @@ pub fn builtin_node_definitions() -> Vec<NodeDefinition> {
     vec![
         (*FLOAT_CONSTANT_NODE_TYPE).clone(),
         (*COLOR_CONSTANT_NODE_TYPE).clone(),
+        (*IMAGE_SOURCE_NODE_TYPE).clone(),
         (*DISPLAY_NODE_TYPE).clone(),
         (*PLOT_NODE_TYPE).clone(),
         (*DELAY_NODE_TYPE).clone(),

--- a/crates/shared/src/graph/node_definition.rs
+++ b/crates/shared/src/graph/node_definition.rs
@@ -14,6 +14,7 @@ pub struct NodeTypeId(String);
 impl NodeTypeId {
     pub const FLOAT_CONSTANT: &'static str = "inputs.float_constant";
     pub const COLOR_CONSTANT: &'static str = "inputs.color_constant";
+    pub const IMAGE_SOURCE: &'static str = "inputs.image_source";
     pub const DISPLAY: &'static str = "outputs.display";
     pub const PLOT: &'static str = "outputs.plot";
     pub const DELAY: &'static str = "temporal_filters.delay";
@@ -381,6 +382,7 @@ pub enum ParameterUiHint {
     ColorGradient,
     Checkbox,
     TextSingleLine,
+    ImageAssetUpload,
     EnumSelect { options: Vec<EnumOption> },
     IntegerDrag { speed: f64, min: i64, max: i64 },
     WledInstanceOrHost,


### PR DESCRIPTION
## Summary
- add a built-in uploaded image source node across shared definitions, backend runtime registration, and frontend editor controls
- add backend image asset storage and decoding support for raster images and SVG uploads
- avoid repeated warning spam when an uploaded image asset is missing by caching the failed load and only logging the warning once per retry window
- update `.gitignore` so backend runtime image asset data stays out of git

## Why
Issue 27 needs a first-class image input node so graphs can render uploaded image assets directly in the runtime and editor preview. The follow-up logging change keeps a missing asset from flooding backend logs while the node continues surfacing a diagnostic to the UI.

## Impact
Users can upload and reference image assets from the editor, render them into graph frames, and see cleaner diagnostics when an asset is missing. Missing files still produce a node diagnostic, but the backend no longer emits the same warning on every tick.

## Testing
- `cargo test -p shared -p backend --locked`
- `cargo test -p frontend --locked`
- `trunk build --release` from `crates/frontend`

## Compatibility
- persisted graphs gain a new built-in node and image asset references, but existing graphs remain compatible
- backend asset files under `crates/backend/data` remain untracked by git