### PR TITLE
feat(nodes): add binary select node

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ With Luma Weaver, you build animation graphs from reusable nodes and run them co
 Current building blocks include:
 
 - animation and pattern nodes such as linear sweep, circle sweep, plasma, twinkle stars, bouncing balls, and level bar
-- math and signal nodes such as constants, add/subtract/multiply/divide, min/max/clamp, abs, map range, power/root/exp/log, rounding, and signal generator
+- math and signal nodes such as constants, add/subtract/multiply/divide, min/max/clamp, abs, map range, binary select, power/root/exp/log, rounding, and signal generator
 - frame and color processing nodes such as tint, mix, blur, Laplacian edge/detail filtering, mask, brightness, and filters
 - runtime/debug nodes such as plot, display, and a WLED dummy display
 - network nodes for WLED output, WLED frame input, audio FFT receive, and Home Assistant MQTT numbers

--- a/crates/backend/src/node_runtime/nodes/math/binary_select.rs
+++ b/crates/backend/src/node_runtime/nodes/math/binary_select.rs
@@ -1,0 +1,246 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use shared::{InputValue, NodeDiagnostic, NodeDiagnosticSeverity, ValueKind};
+
+use crate::node_runtime::{
+    AnyInputValue, NodeEvaluationContext, RuntimeInputs, RuntimeNode, RuntimeNodeFromParameters,
+    TypedNodeEvaluation,
+};
+
+#[derive(Default)]
+pub(crate) struct BinarySelectNode;
+
+impl RuntimeNodeFromParameters for BinarySelectNode {}
+
+pub(crate) struct BinarySelectInputs {
+    selector: f32,
+    a: AnyInputValue,
+    b: AnyInputValue,
+}
+
+impl RuntimeInputs for BinarySelectInputs {
+    fn from_runtime_inputs(inputs: &HashMap<String, InputValue>) -> Result<Self> {
+        Ok(Self {
+            selector: match inputs.get("selector") {
+                Some(InputValue::Float(value)) => *value,
+                Some(_) | None => 0.0,
+            },
+            a: AnyInputValue(inputs.get("a").cloned().unwrap_or(InputValue::Float(0.0))),
+            b: AnyInputValue(inputs.get("b").cloned().unwrap_or(InputValue::Float(0.0))),
+        })
+    }
+}
+
+pub(crate) struct BinarySelectOutputs {
+    value: InputValue,
+}
+
+crate::node_runtime::impl_runtime_outputs!(BinarySelectOutputs { value });
+
+impl RuntimeNode for BinarySelectNode {
+    type Inputs = BinarySelectInputs;
+    type Outputs = BinarySelectOutputs;
+
+    fn evaluate(
+        &mut self,
+        _context: &NodeEvaluationContext,
+        inputs: Self::Inputs,
+    ) -> Result<TypedNodeEvaluation<Self::Outputs>> {
+        let selects_b = selects_b(inputs.selector);
+        let a = inputs.a.0;
+        let b = inputs.b.0;
+        let a_kind = value_kind(&a);
+        let b_kind = value_kind(&b);
+
+        let mut diagnostics = Vec::new();
+        if a_kind != b_kind {
+            diagnostics.push(NodeDiagnostic {
+                severity: NodeDiagnosticSeverity::Warning,
+                code: Some("binary_select_kind_mismatch".to_owned()),
+                message: format!(
+                    "Binary Select received different branch kinds ({:?} and {:?}); using the selected branch value.",
+                    a_kind, b_kind
+                ),
+            });
+        }
+
+        let selected = if selects_b { b } else { a };
+
+        Ok(TypedNodeEvaluation {
+            outputs: BinarySelectOutputs { value: selected },
+            frontend_updates: Vec::new(),
+            diagnostics,
+        })
+    }
+}
+
+fn selects_b(selector: f32) -> bool {
+    selector >= 0.5
+}
+
+fn value_kind(value: &InputValue) -> ValueKind {
+    match value {
+        InputValue::Float(_) => ValueKind::Float,
+        InputValue::FloatTensor(_) => ValueKind::FloatTensor,
+        InputValue::Color(_) => ValueKind::Color,
+        InputValue::LedLayout(_) => ValueKind::LedLayout,
+        InputValue::ColorFrame(_) => ValueKind::ColorFrame,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use shared::{ColorFrame, FloatTensor, InputValue, LedLayout, RgbaColor};
+
+    use super::{BinarySelectInputs, BinarySelectNode, selects_b};
+    use crate::node_runtime::{AnyInputValue, NodeEvaluationContext, RuntimeInputs, RuntimeNode};
+
+    fn evaluation_context() -> NodeEvaluationContext {
+        NodeEvaluationContext {
+            graph_id: "graph".to_owned(),
+            graph_name: "Graph".to_owned(),
+            elapsed_seconds: 0.0,
+            render_layout: None,
+        }
+    }
+
+    #[test]
+    fn selector_threshold_matches_issue_contract() {
+        assert!(!selects_b(0.49));
+        assert!(selects_b(0.5));
+        assert!(selects_b(1.0));
+    }
+
+    #[test]
+    fn selector_below_threshold_returns_a() {
+        let mut node = BinarySelectNode;
+        let evaluation = node
+            .evaluate(
+                &evaluation_context(),
+                BinarySelectInputs {
+                    selector: 0.25,
+                    a: AnyInputValue(InputValue::Float(2.0)),
+                    b: AnyInputValue(InputValue::Float(7.0)),
+                },
+            )
+            .expect("evaluate binary select");
+
+        assert_eq!(evaluation.outputs.value, InputValue::Float(2.0));
+    }
+
+    #[test]
+    fn selector_at_threshold_returns_b() {
+        let mut node = BinarySelectNode;
+        let evaluation = node
+            .evaluate(
+                &evaluation_context(),
+                BinarySelectInputs {
+                    selector: 0.5,
+                    a: AnyInputValue(InputValue::Float(2.0)),
+                    b: AnyInputValue(InputValue::Float(7.0)),
+                },
+            )
+            .expect("evaluate binary select");
+
+        assert_eq!(evaluation.outputs.value, InputValue::Float(7.0));
+    }
+
+    #[test]
+    fn preserves_selected_value_kind_for_frames() {
+        let mut node = BinarySelectNode;
+        let frame = InputValue::ColorFrame(ColorFrame {
+            layout: LedLayout {
+                id: "frame".to_owned(),
+                pixel_count: 2,
+                width: Some(2),
+                height: Some(1),
+            },
+            pixels: vec![
+                RgbaColor {
+                    r: 1.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                },
+                RgbaColor {
+                    r: 0.0,
+                    g: 1.0,
+                    b: 0.0,
+                    a: 1.0,
+                },
+            ],
+        });
+
+        let evaluation = node
+            .evaluate(
+                &evaluation_context(),
+                BinarySelectInputs {
+                    selector: 1.0,
+                    a: AnyInputValue(InputValue::Float(0.0)),
+                    b: AnyInputValue(frame.clone()),
+                },
+            )
+            .expect("evaluate binary select");
+
+        assert_eq!(evaluation.outputs.value, frame);
+    }
+
+    #[test]
+    fn preserves_selected_value_kind_for_tensors() {
+        let mut node = BinarySelectNode;
+        let tensor = InputValue::FloatTensor(FloatTensor {
+            shape: vec![3],
+            values: vec![0.25, 0.5, 0.75],
+        });
+
+        let evaluation = node
+            .evaluate(
+                &evaluation_context(),
+                BinarySelectInputs {
+                    selector: 1.0,
+                    a: AnyInputValue(InputValue::Float(0.0)),
+                    b: AnyInputValue(tensor.clone()),
+                },
+            )
+            .expect("evaluate binary select");
+
+        assert_eq!(evaluation.outputs.value, tensor);
+    }
+
+    #[test]
+    fn runtime_defaults_fall_back_to_zero_for_missing_inputs() {
+        let inputs = BinarySelectInputs::from_runtime_inputs(&HashMap::new())
+            .expect("default runtime inputs");
+
+        assert_eq!(inputs.selector, 0.0);
+        assert_eq!(inputs.a.0, InputValue::Float(0.0));
+        assert_eq!(inputs.b.0, InputValue::Float(0.0));
+    }
+
+    #[test]
+    fn mismatched_branch_kinds_emit_warning() {
+        let mut node = BinarySelectNode;
+        let evaluation = node
+            .evaluate(
+                &evaluation_context(),
+                BinarySelectInputs {
+                    selector: 0.0,
+                    a: AnyInputValue(InputValue::Float(1.0)),
+                    b: AnyInputValue(InputValue::Color(RgbaColor {
+                        r: 1.0,
+                        g: 1.0,
+                        b: 1.0,
+                        a: 1.0,
+                    })),
+                },
+            )
+            .expect("evaluate binary select");
+
+        assert!(evaluation.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code.as_deref() == Some("binary_select_kind_mismatch")
+        }));
+    }
+}

--- a/crates/backend/src/node_runtime/nodes/math/mod.rs
+++ b/crates/backend/src/node_runtime/nodes/math/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod abs_float;
 pub(crate) mod add_float;
+pub(crate) mod binary_select;
 pub(crate) mod clamp_float;
 pub(crate) mod divide_float;
 pub(crate) mod exponential_float;

--- a/crates/backend/src/node_runtime/registry.rs
+++ b/crates/backend/src/node_runtime/registry.rs
@@ -192,6 +192,10 @@ fn build_registry(target: NodeExecutionTarget) -> anyhow::Result<Arc<NodeRegistr
         NodeTypeId::SIGNAL_GENERATOR,
         nodes::inputs::signal_generator::SignalGeneratorNode
     );
+    register_builtin!(
+        NodeTypeId::BINARY_SELECT,
+        nodes::math::binary_select::BinarySelectNode
+    );
     register_builtin!(NodeTypeId::ADD_FLOAT, nodes::math::add_float::AddFloatNode);
     register_builtin!(
         NodeTypeId::SUBTRACT_FLOAT,

--- a/crates/backend/src/services/runtime/executor.rs
+++ b/crates/backend/src/services/runtime/executor.rs
@@ -416,6 +416,79 @@ mod tests {
             .expect("execute sample graph tick");
     }
 
+    #[test]
+    fn binary_select_graph_executes_one_tick() {
+        let document: GraphDocument = serde_json::from_value(serde_json::json!({
+            "metadata": {
+                "id": "binary-select-sample",
+                "name": "binary select sample",
+                "execution_frequency_hz": 60
+            },
+            "nodes": [
+                {
+                    "id": "selector",
+                    "metadata": { "name": "selector" },
+                    "node_type": "inputs.float_constant",
+                    "parameters": [{ "name": "value", "value": 1.0 }]
+                },
+                {
+                    "id": "a",
+                    "metadata": { "name": "a" },
+                    "node_type": "inputs.float_constant",
+                    "parameters": [{ "name": "value", "value": 2.0 }]
+                },
+                {
+                    "id": "b",
+                    "metadata": { "name": "b" },
+                    "node_type": "inputs.float_constant",
+                    "parameters": [{ "name": "value", "value": 7.0 }]
+                },
+                {
+                    "id": "select",
+                    "metadata": { "name": "select" },
+                    "node_type": "math.binary_select"
+                }
+            ],
+            "edges": [
+                {
+                    "from_node_id": "selector",
+                    "from_output_name": "value",
+                    "to_node_id": "select",
+                    "to_input_name": "selector"
+                },
+                {
+                    "from_node_id": "a",
+                    "from_output_name": "value",
+                    "to_node_id": "select",
+                    "to_input_name": "a"
+                },
+                {
+                    "from_node_id": "b",
+                    "from_output_name": "value",
+                    "to_node_id": "select",
+                    "to_input_name": "b"
+                }
+            ]
+        }))
+        .expect("parse binary select graph");
+
+        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let mut graph =
+            compile_graph_document(document, node_registry).expect("compile binary select graph");
+        let mut execution_state = GraphExecutionState::default();
+
+        graph
+            .execute_tick("binary-select-sample", &NoopEvents, 0.0, &mut execution_state)
+            .expect("execute binary select graph tick");
+
+        let selected = execution_state
+            .previous_outputs
+            .get(&(3usize, "__default__".to_owned(), "value".to_owned()))
+            .cloned()
+            .expect("binary select output");
+        assert_eq!(selected, InputValue::Float(7.0));
+    }
+
     /// Measures the average tick time for the sample runtime graph.
     #[test]
     fn sample_runtime_graph_tick_timing() {

--- a/crates/shared/src/graph/builtin_nodes.rs
+++ b/crates/shared/src/graph/builtin_nodes.rs
@@ -545,6 +545,48 @@ static HA_MQTT_NUMBER_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| Nod
     runtime_updates: None,
 });
 
+static BINARY_SELECT_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
+    id: NodeTypeId::BINARY_SELECT.to_owned(),
+    display_name: "Binary Select".to_owned(),
+    category: NodeCategory::Math,
+    needs_io: false,
+    inputs: vec![
+        NodeInputDefinition {
+            name: "selector".to_owned(),
+            display_name: title_case_name("selector"),
+            value_kind: ValueKind::Float,
+            accepted_kinds: vec![],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+        NodeInputDefinition {
+            name: "a".to_owned(),
+            display_name: title_case_name("a"),
+            value_kind: ValueKind::Any,
+            accepted_kinds: vec![],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+        NodeInputDefinition {
+            name: "b".to_owned(),
+            display_name: title_case_name("b"),
+            value_kind: ValueKind::Any,
+            accepted_kinds: vec![],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+    ],
+    outputs: vec![NodeOutputDefinition {
+        name: "value".to_owned(),
+        display_name: title_case_name("value"),
+        value_kind: ValueKind::Any,
+        accepted_kinds: vec![],
+    }],
+    parameters: vec![],
+    connection: NodeConnectionDefinition {
+        max_input_connections: 1,
+        require_value_kind_match: true,
+    },
+    runtime_updates: None,
+});
+
 static ADD_FLOAT_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
     id: NodeTypeId::ADD_FLOAT.to_owned(),
     display_name: "Add Float".to_owned(),
@@ -2109,6 +2151,7 @@ pub fn builtin_node_definitions() -> Vec<NodeDefinition> {
         (*WLED_SINK_NODE_TYPE).clone(),
         (*AUDIO_FFT_RECEIVER_NODE_TYPE).clone(),
         (*HA_MQTT_NUMBER_NODE_TYPE).clone(),
+        (*BINARY_SELECT_NODE_TYPE).clone(),
         (*ADD_FLOAT_NODE_TYPE).clone(),
         (*SUBTRACT_FLOAT_NODE_TYPE).clone(),
         (*SIGNAL_GENERATOR_NODE_TYPE).clone(),

--- a/crates/shared/src/graph/node_definition.rs
+++ b/crates/shared/src/graph/node_definition.rs
@@ -22,6 +22,7 @@ impl NodeTypeId {
     pub const AUDIO_FFT_RECEIVER: &'static str = "inputs.audio_fft_receiver";
     pub const HA_MQTT_NUMBER: &'static str = "inputs.ha_mqtt_number";
     pub const SIGNAL_GENERATOR: &'static str = "inputs.signal_generator";
+    pub const BINARY_SELECT: &'static str = "math.binary_select";
     pub const ADD_FLOAT: &'static str = "math.add_float";
     pub const SUBTRACT_FLOAT: &'static str = "math.subtract_float";
     pub const DIVIDE_FLOAT: &'static str = "math.divide_float";


### PR DESCRIPTION
## Summary
Adds a first-scope `Binary Select` node for conditional value routing in graphs.

## Why
Issue #19 asks for a direct way to choose between multiple values based on a control input. This branch implements the binary version of that design so existing float-based control signals can route values without arithmetic workarounds.

## What Changed
- added shared node-definition support for `math.binary_select`
- registered the node in the backend runtime
- implemented backend evaluation logic that selects `a` for selector values below `0.5` and `b` for selector values at or above `0.5`
- preserved pass-through behavior for supported value kinds and emitted a warning diagnostic when branch kinds differ
- added backend runtime and graph execution tests
- updated the README node catalog entry

## Impact
Graphs can now branch between two values using a simple control signal, which covers the initial conditional-routing use case described in the issue.

## Testing
- `cargo test -p backend binary_select --locked`

## Compatibility
- persisted graph compatibility is preserved
- this adds a new built-in node without changing existing node ids or parameter shapes

Closes #19