### PR TITLE
feat(editor): support node selection and clipboard copy/paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "shared",
  "tracing",
  "tracing-wasm",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Current building blocks include:
 - runtime/debug nodes such as plot, display, and a WLED dummy display
 - network nodes for WLED output, WLED frame input, audio FFT receive, and Home Assistant MQTT numbers
 
+The editor also supports multi-select graph editing with node-group dragging plus clipboard copy and paste via `Ctrl/Cmd+C` and `Ctrl/Cmd+V`.
+
 ## Quick Start
 
 ### Standalone With Docker Compose

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 shared = { path = "../shared" }
 tracing.workspace = true
+uuid = { workspace = true, features = ["js", "v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1"
@@ -30,4 +31,4 @@ js-sys = "0.3"
 tracing-wasm.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures = "0.4"
-web-sys = { workspace = true, features = ["Blob", "Document", "Event", "File", "FileList", "FileReader", "Headers", "History", "HtmlAnchorElement", "HtmlCanvasElement", "HtmlInputElement", "Location", "Request", "RequestInit", "Response", "Url", "Window"] }
+web-sys = { workspace = true, features = ["Blob", "Clipboard", "Document", "Event", "File", "FileList", "FileReader", "Headers", "History", "HtmlAnchorElement", "HtmlCanvasElement", "HtmlInputElement", "Location", "Navigator", "Request", "RequestInit", "Response", "Url", "Window"] }

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -1,3 +1,4 @@
+mod clipboard;
 mod graph_actions;
 mod history;
 mod image_assets;
@@ -47,6 +48,7 @@ impl eframe::App for FrontendApp {
         self.ensure_runtime_updates_subscription();
         self.drain_server_messages(ctx);
         self.drain_browser_graph_file_events();
+        self.drain_browser_clipboard_events();
         self.drain_browser_image_asset_events();
         crate::header_view::render(ctx, self);
 

--- a/crates/frontend/src/app/clipboard.rs
+++ b/crates/frontend/src/app/clipboard.rs
@@ -1,0 +1,256 @@
+use shared::{GraphClipboardFragment, NodePosition};
+
+use super::FrontendApp;
+
+impl FrontendApp {
+    /// Copies the currently selected nodes to the system clipboard.
+    pub(crate) fn copy_selected_nodes_to_clipboard(&mut self) {
+        let selected_node_ids = self
+            .ui
+            .selected_graph_node_ids
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        self.ui.pending_clipboard_read_graph_id = None;
+        if selected_node_ids.is_empty() {
+            self.ui.status = "Select one or more nodes to copy".to_owned();
+            return;
+        }
+
+        let Some(document) = self.active_graph_document_mut().cloned() else {
+            self.ui.status = "No graph document is loaded".to_owned();
+            return;
+        };
+        let Some(fragment) =
+            crate::editor_view::clipboard_fragment_from_document(&document, &selected_node_ids)
+        else {
+            self.ui.status = "Nothing selected to copy".to_owned();
+            return;
+        };
+
+        let payload = match serde_json::to_string_pretty(&fragment) {
+            Ok(payload) => payload,
+            Err(error) => {
+                self.ui.status = format!("Failed to serialize clipboard fragment: {error}");
+                return;
+            }
+        };
+
+        match crate::browser_file::write_text_to_clipboard(payload) {
+            Ok(receiver) => {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    self.ui.browser_clipboard_events = Some(receiver);
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let _ = receiver;
+                }
+                self.ui.status = format!("Copying {} node(s) to clipboard", fragment.nodes.len());
+            }
+            Err(message) => {
+                self.ui.status = message;
+            }
+        }
+    }
+
+    /// Starts a clipboard read so the current graph can paste any copied node fragment.
+    pub(crate) fn paste_nodes_from_clipboard(&mut self) {
+        let Some(target_graph_id) = self.ui.selected_graph_id.clone() else {
+            self.ui.status = "No graph document is loaded".to_owned();
+            return;
+        };
+        if self.active_graph_document_mut().is_none() {
+            self.ui.status = "No graph document is loaded".to_owned();
+            return;
+        }
+
+        match crate::browser_file::read_text_from_clipboard() {
+            Ok(receiver) => {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    self.ui.browser_clipboard_events = Some(receiver);
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let _ = receiver;
+                }
+                self.ui.pending_clipboard_read_graph_id = Some(target_graph_id);
+                self.ui.status = "Reading clipboard".to_owned();
+            }
+            Err(message) => {
+                self.ui.pending_clipboard_read_graph_id = None;
+                self.ui.status = message;
+            }
+        }
+    }
+
+    /// Drains asynchronous clipboard events triggered by browser clipboard APIs.
+    pub(super) fn drain_browser_clipboard_events(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            return;
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            use futures_channel::mpsc::TryRecvError;
+
+            let Some(receiver) = &mut self.ui.browser_clipboard_events else {
+                return;
+            };
+
+            let mut events = Vec::new();
+            let mut receiver_closed = false;
+            loop {
+                match receiver.try_recv() {
+                    Ok(event) => events.push(event),
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Closed) => {
+                        receiver_closed = true;
+                        break;
+                    }
+                }
+            }
+
+            if !events.is_empty() {
+                self.ui.browser_clipboard_events = None;
+            } else if receiver_closed {
+                self.ui.browser_clipboard_events = None;
+                return;
+            }
+
+            for event in events {
+                match event {
+                    crate::browser_file::BrowserClipboardEvent::Copied => {
+                        let copied_count = self.ui.selected_graph_node_ids.len();
+                        self.ui.status = format!("Copied {copied_count} node(s) to clipboard");
+                    }
+                    crate::browser_file::BrowserClipboardEvent::Read(text) => {
+                        if let Err(message) = self.ensure_pending_clipboard_paste_targets_active_graph()
+                        {
+                            self.ui.pending_clipboard_read_graph_id = None;
+                            self.ui.status = message;
+                            continue;
+                        }
+                        self.handle_clipboard_text(text);
+                        self.ui.pending_clipboard_read_graph_id = None;
+                    }
+                    crate::browser_file::BrowserClipboardEvent::Error(message) => {
+                        self.ui.pending_clipboard_read_graph_id = None;
+                        self.ui.status = message;
+                    }
+                }
+            }
+        }
+    }
+
+    fn ensure_pending_clipboard_paste_targets_active_graph(&self) -> Result<(), String> {
+        let Some(target_graph_id) = self.ui.pending_clipboard_read_graph_id.as_deref() else {
+            return Ok(());
+        };
+        let selected_graph_id = self.ui.selected_graph_id.as_deref();
+        let loaded_graph_id = self
+            .graphs
+            .loaded_graph_document
+            .as_ref()
+            .map(|document| document.metadata.id.as_str());
+
+        if selected_graph_id == Some(target_graph_id) && loaded_graph_id == Some(target_graph_id) {
+            Ok(())
+        } else {
+            Err("Clipboard paste was cancelled because the active graph changed".to_owned())
+        }
+    }
+
+    fn handle_clipboard_text(&mut self, text: String) {
+        let fragment = match serde_json::from_str::<GraphClipboardFragment>(&text) {
+            Ok(fragment) => fragment,
+            Err(error) => {
+                self.ui.status =
+                    format!("Clipboard does not contain a valid graph fragment: {error}");
+                return;
+            }
+        };
+        if let Err(message) = fragment.validate_header() {
+            self.ui.status = message;
+            return;
+        }
+
+        let available_node_definitions = self.graphs.available_node_definitions.clone();
+        let paste_origin = self.preferred_paste_origin();
+        let (pasted_node_count, skipped_node_type_ids, inserted_node_ids) = {
+            let Some(document) = self.active_graph_document_mut() else {
+                self.ui.status = "No graph document is loaded".to_owned();
+                return;
+            };
+            let result = crate::editor_view::paste_clipboard_fragment_into_document(
+                document,
+                &fragment,
+                &available_node_definitions,
+                paste_origin,
+            );
+            (
+                result.inserted_node_ids.len(),
+                result.skipped_node_type_ids,
+                result.inserted_node_ids,
+            )
+        };
+
+        self.ui.selected_graph_node_ids = inserted_node_ids;
+        self.sync_live_snarl_from_loaded_document();
+        self.ui.status = if pasted_node_count == 0 {
+            if skipped_node_type_ids.is_empty() {
+                "Clipboard fragment did not contain any pasteable nodes".to_owned()
+            } else {
+                format!(
+                    "Skipped unsupported node types: {}",
+                    skipped_node_type_ids.join(", ")
+                )
+            }
+        } else if skipped_node_type_ids.is_empty() {
+            format!("Pasted {pasted_node_count} node(s)")
+        } else {
+            format!(
+                "Pasted {pasted_node_count} node(s), skipped unsupported node types: {}",
+                skipped_node_type_ids.join(", ")
+            )
+        };
+    }
+
+    fn preferred_paste_origin(&self) -> Option<NodePosition> {
+        if !self.ui.editor_canvas_hovered {
+            return None;
+        }
+        self.ui
+            .editor_pointer_graph_position
+            .map(|(x, y)| NodePosition { x, y })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shared::{GraphDocument, GraphMetadata};
+
+    use crate::app::FrontendApp;
+
+    #[test]
+    fn pending_clipboard_paste_is_rejected_after_graph_switch() {
+        let mut app = FrontendApp::default();
+        app.ui.selected_graph_id = Some("graph-b".to_owned());
+        app.ui.pending_clipboard_read_graph_id = Some("graph-a".to_owned());
+        app.graphs.loaded_graph_document = Some(GraphDocument {
+            metadata: GraphMetadata {
+                id: "graph-b".to_owned(),
+                name: "Graph B".to_owned(),
+                execution_frequency_hz: 60,
+            },
+            ..GraphDocument::default()
+        });
+
+        assert_eq!(
+            app.ensure_pending_clipboard_paste_targets_active_graph(),
+            Err("Clipboard paste was cancelled because the active graph changed".to_owned())
+        );
+    }
+}

--- a/crates/frontend/src/app/history.rs
+++ b/crates/frontend/src/app/history.rs
@@ -89,25 +89,38 @@ impl FrontendApp {
             return;
         }
 
-        let (undo_pressed, redo_pressed, mouse_back_pressed, mouse_forward_pressed) =
-            ctx.input(|input| {
-                let undo_pressed = input.modifiers.command
-                    && !input.modifiers.shift
-                    && input.key_pressed(egui::Key::Z);
-                let redo_pressed = (input.modifiers.command && input.key_pressed(egui::Key::Y))
-                    || (input.modifiers.command
-                        && input.modifiers.shift
-                        && input.key_pressed(egui::Key::Z));
-                let mouse_back_pressed = input.pointer.button_pressed(egui::PointerButton::Extra1);
-                let mouse_forward_pressed =
-                    input.pointer.button_pressed(egui::PointerButton::Extra2);
-                (
-                    undo_pressed,
-                    redo_pressed,
-                    mouse_back_pressed,
-                    mouse_forward_pressed,
-                )
-            });
+        let (
+            undo_pressed,
+            redo_pressed,
+            copy_pressed,
+            paste_pressed,
+            mouse_back_pressed,
+            mouse_forward_pressed,
+        ) = ctx.input(|input| {
+            let undo_pressed = input.modifiers.command
+                && !input.modifiers.shift
+                && input.key_pressed(egui::Key::Z);
+            let redo_pressed = (input.modifiers.command && input.key_pressed(egui::Key::Y))
+                || (input.modifiers.command
+                    && input.modifiers.shift
+                    && input.key_pressed(egui::Key::Z));
+            let copy_pressed = input.modifiers.command
+                && !input.modifiers.shift
+                && input.key_pressed(egui::Key::C);
+            let paste_pressed = input.modifiers.command
+                && !input.modifiers.shift
+                && input.key_pressed(egui::Key::V);
+            let mouse_back_pressed = input.pointer.button_pressed(egui::PointerButton::Extra1);
+            let mouse_forward_pressed = input.pointer.button_pressed(egui::PointerButton::Extra2);
+            (
+                undo_pressed,
+                redo_pressed,
+                copy_pressed,
+                paste_pressed,
+                mouse_back_pressed,
+                mouse_forward_pressed,
+            )
+        });
 
         if undo_pressed {
             self.undo_graph_edit();
@@ -115,6 +128,14 @@ impl FrontendApp {
         }
         if redo_pressed {
             self.redo_graph_edit();
+            return;
+        }
+        if copy_pressed {
+            self.copy_selected_nodes_to_clipboard();
+            return;
+        }
+        if paste_pressed {
+            self.paste_nodes_from_clipboard();
             return;
         }
         if mouse_back_pressed {

--- a/crates/frontend/src/app/navigation.rs
+++ b/crates/frontend/src/app/navigation.rs
@@ -239,6 +239,9 @@ impl FrontendApp {
         self.ui.selected_graph_id = Some(graph_id.clone());
         self.ui.node_menu_search.clear();
         self.ui.node_menu_graph_position = None;
+        self.ui.selected_graph_node_ids.clear();
+        self.ui.editor_pointer_graph_position = None;
+        self.ui.pending_clipboard_read_graph_id = None;
         self.ui.rename_graph_dialog_open = false;
         self.ui.rename_graph_id = Some(graph_id.clone());
         self.ui.rename_graph_name.clear();

--- a/crates/frontend/src/app/server_state.rs
+++ b/crates/frontend/src/app/server_state.rs
@@ -271,6 +271,9 @@ impl FrontendApp {
     pub(crate) fn clear_selected_graph_session(&mut self) {
         self.ui.selected_graph_id = None;
         self.ui.editor_canvas_hovered = false;
+        self.ui.selected_graph_node_ids.clear();
+        self.ui.editor_pointer_graph_position = None;
+        self.ui.pending_clipboard_read_graph_id = None;
         self.ui.node_menu_search.clear();
         self.ui.node_menu_graph_position = None;
         self.ui.rename_graph_dialog_open = false;
@@ -290,6 +293,10 @@ impl FrontendApp {
         self.graphs.plot_history.clear();
         self.ui.diagnostics_window_graph_id = None;
         self.ui.diagnostics_window_node_id = None;
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.ui.browser_clipboard_events = None;
+        }
     }
 
     /// Clears autosave bookkeeping for pending local graph edits.

--- a/crates/frontend/src/browser_file.rs
+++ b/crates/frontend/src/browser_file.rs
@@ -17,6 +17,13 @@ pub(crate) enum BrowserImageAssetEvent {
     Error(String),
 }
 
+/// Represents the outcome of a browser-managed clipboard interaction.
+pub(crate) enum BrowserClipboardEvent {
+    Copied,
+    Read(String),
+    Error(String),
+}
+
 #[cfg(target_arch = "wasm32")]
 /// Opens the browser file picker for graph import and returns a stream of parse results.
 ///
@@ -162,6 +169,68 @@ pub(crate) fn download_graph_export(
     _file: &GraphExchangeFile,
 ) -> Result<(), String> {
     Err("Graph export is only available in the browser build".to_owned())
+}
+
+#[cfg(target_arch = "wasm32")]
+/// Writes text to the browser clipboard and reports the async result through a receiver.
+pub(crate) fn write_text_to_clipboard(
+    text: String,
+) -> Result<mpsc::UnboundedReceiver<BrowserClipboardEvent>, String> {
+    use wasm_bindgen_futures::spawn_local;
+
+    let Some(window) = web_sys::window() else {
+        return Err("Browser window is unavailable".to_owned());
+    };
+    let clipboard = window.navigator().clipboard();
+    let (sender, receiver) = mpsc::unbounded();
+
+    spawn_local(async move {
+        let event = match wasm_bindgen_futures::JsFuture::from(clipboard.write_text(&text)).await {
+            Ok(_) => BrowserClipboardEvent::Copied,
+            Err(_) => BrowserClipboardEvent::Error("Failed to write to clipboard".to_owned()),
+        };
+        let _ = sender.unbounded_send(event);
+    });
+
+    Ok(receiver)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Reports that clipboard writes are unavailable on non-wasm builds.
+pub(crate) fn write_text_to_clipboard(
+    _text: String,
+) -> Result<mpsc::UnboundedReceiver<BrowserClipboardEvent>, String> {
+    Err("Clipboard access is only available in the browser build".to_owned())
+}
+
+#[cfg(target_arch = "wasm32")]
+/// Reads text from the browser clipboard and reports the async result through a receiver.
+pub(crate) fn read_text_from_clipboard()
+-> Result<mpsc::UnboundedReceiver<BrowserClipboardEvent>, String> {
+    use wasm_bindgen_futures::spawn_local;
+
+    let Some(window) = web_sys::window() else {
+        return Err("Browser window is unavailable".to_owned());
+    };
+    let clipboard = window.navigator().clipboard();
+    let (sender, receiver) = mpsc::unbounded();
+
+    spawn_local(async move {
+        let event = match wasm_bindgen_futures::JsFuture::from(clipboard.read_text()).await {
+            Ok(value) => BrowserClipboardEvent::Read(value.as_string().unwrap_or_default()),
+            Err(_) => BrowserClipboardEvent::Error("Failed to read clipboard".to_owned()),
+        };
+        let _ = sender.unbounded_send(event);
+    });
+
+    Ok(receiver)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Reports that clipboard reads are unavailable on non-wasm builds.
+pub(crate) fn read_text_from_clipboard()
+-> Result<mpsc::UnboundedReceiver<BrowserClipboardEvent>, String> {
+    Err("Clipboard access is only available in the browser build".to_owned())
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/frontend/src/editor_view.rs
+++ b/crates/frontend/src/editor_view.rs
@@ -42,13 +42,13 @@ pub(crate) struct EditorSnarlNode {
 }
 
 pub(crate) use self::model::{
-    build_snarl_from_document, patch_snarl_from_document, refresh_snarl_runtime_values,
+    build_snarl_from_document, clipboard_fragment_from_document,
+    paste_clipboard_fragment_into_document, patch_snarl_from_document,
+    refresh_snarl_runtime_values,
 };
 
 #[cfg(test)]
-pub(crate) fn snarl_node_titles(
-    snarl: &egui_snarl::Snarl<EditorSnarlNode>,
-) -> Vec<String> {
+pub(crate) fn snarl_node_titles(snarl: &egui_snarl::Snarl<EditorSnarlNode>) -> Vec<String> {
     snarl.nodes().map(|node| node.title.clone()).collect()
 }
 
@@ -160,6 +160,18 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                             app.redo_graph_edit();
                         }
 
+                        let copy_response = ui.add_enabled(
+                            !app.ui.selected_graph_node_ids.is_empty(),
+                            secondary_action_button("Copy"),
+                        );
+                        if copy_response.clicked() {
+                            app.copy_selected_nodes_to_clipboard();
+                        }
+
+                        if ui.add(secondary_action_button("Paste")).clicked() {
+                            app.paste_nodes_from_clipboard();
+                        }
+
                         if ui.add(secondary_action_button("Export")).clicked() {
                             app.request_graph_export(graph.id.clone());
                         }
@@ -220,6 +232,8 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                     initialized,
                     opened_diagnostics_node_id,
                     canvas_hovered,
+                    selected_graph_node_ids,
+                    editor_pointer_graph_position,
                     node_menu_search,
                     node_menu_graph_position,
                     image_upload_request,
@@ -239,6 +253,9 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                 );
                 initialized_viewport_for_graph = initialized;
                 app.ui.editor_canvas_hovered = canvas_hovered;
+                app.ui.selected_graph_node_ids = selected_graph_node_ids;
+                app.ui.editor_pointer_graph_position =
+                    editor_pointer_graph_position.map(|pos| (pos.x, pos.y));
                 app.ui.node_menu_search = node_menu_search;
                 app.ui.node_menu_graph_position =
                     node_menu_graph_position.map(|pos| (pos.x, pos.y));
@@ -255,6 +272,8 @@ pub(crate) fn render(ui: &mut egui::Ui, app: &mut FrontendApp) {
                         ui.label("Waiting for the backend to send the latest saved version.");
                     });
                 });
+                app.ui.selected_graph_node_ids.clear();
+                app.ui.editor_pointer_graph_position = None;
             }
             if initialized_viewport_for_graph {
                 app.graphs.snarl_viewport_initialized_graph_id = Some(graph.id.clone());

--- a/crates/frontend/src/editor_view/model.rs
+++ b/crates/frontend/src/editor_view/model.rs
@@ -1,10 +1,12 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use egui_snarl::{NodeId, Snarl};
 use shared::{
-    GraphDocument, GraphEdge, GraphNode, InputValue, NodeDefinition, NodeInputValue, NodeMetadata,
-    NodeParameter, NodeParameterDefinition, NodeTypeId, ValueKind,
+    GraphClipboardFragment, GraphDocument, GraphEdge, GraphNode, InputValue, NodeDefinition,
+    NodeInputValue, NodeMetadata, NodeParameter, NodeParameterDefinition, NodePosition, NodeTypeId,
+    ValueKind,
 };
+use uuid::Uuid;
 
 use super::{EditorInputPort, EditorOutputPort, EditorSnarlNode};
 
@@ -613,13 +615,147 @@ pub(crate) fn patch_snarl_from_document(
     }
 }
 
+/// Summarizes the result of pasting a clipboard fragment into a graph document.
+pub(crate) struct PasteClipboardFragmentResult {
+    pub(crate) inserted_node_ids: Vec<String>,
+    pub(crate) skipped_node_type_ids: Vec<String>,
+}
+
+/// Builds a clipboard fragment from the selected nodes in a graph document.
+pub(crate) fn clipboard_fragment_from_document(
+    document: &GraphDocument,
+    selected_node_ids: &HashSet<String>,
+) -> Option<GraphClipboardFragment> {
+    if selected_node_ids.is_empty() {
+        return None;
+    }
+
+    let nodes = document
+        .nodes
+        .iter()
+        .filter(|node| selected_node_ids.contains(node.id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if nodes.is_empty() {
+        return None;
+    }
+
+    let origin = clipboard_fragment_origin(&nodes);
+    let edges = document
+        .edges
+        .iter()
+        .filter(|edge| {
+            selected_node_ids.contains(edge.from_node_id.as_str())
+                && selected_node_ids.contains(edge.to_node_id.as_str())
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Some(GraphClipboardFragment::new(origin, nodes, edges))
+}
+
+/// Pastes a clipboard fragment into the graph document, generating fresh node IDs.
+pub(crate) fn paste_clipboard_fragment_into_document(
+    document: &mut GraphDocument,
+    fragment: &GraphClipboardFragment,
+    available_node_definitions: &[NodeDefinition],
+    paste_origin: Option<NodePosition>,
+) -> PasteClipboardFragmentResult {
+    let target_origin = paste_origin.unwrap_or_else(|| NodePosition {
+        x: fragment.origin.x + 32.0,
+        y: fragment.origin.y + 32.0,
+    });
+    let delta_x = target_origin.x - fragment.origin.x;
+    let delta_y = target_origin.y - fragment.origin.y;
+
+    let available_node_type_ids = available_node_definitions
+        .iter()
+        .map(|definition| definition.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut id_map = HashMap::<String, String>::new();
+    let mut skipped_node_type_ids = Vec::<String>::new();
+
+    for node in &fragment.nodes {
+        if !available_node_type_ids.contains(node.node_type.as_str()) {
+            if skipped_node_type_ids
+                .iter()
+                .all(|node_type_id| node_type_id != node.node_type.as_str())
+            {
+                skipped_node_type_ids.push(node.node_type.as_str().to_owned());
+            }
+            continue;
+        }
+
+        let new_node_id = Uuid::new_v4().to_string();
+        id_map.insert(node.id.clone(), new_node_id.clone());
+
+        let mut pasted_node = node.clone();
+        pasted_node.id = new_node_id.clone();
+        pasted_node.viewport.position.x += delta_x;
+        pasted_node.viewport.position.y += delta_y;
+        document.nodes.push(pasted_node);
+    }
+
+    for edge in &fragment.edges {
+        let Some(from_node_id) = id_map.get(edge.from_node_id.as_str()) else {
+            continue;
+        };
+        let Some(to_node_id) = id_map.get(edge.to_node_id.as_str()) else {
+            continue;
+        };
+
+        document.edges.push(GraphEdge {
+            from_node_id: from_node_id.clone(),
+            from_output_name: edge.from_output_name.clone(),
+            to_node_id: to_node_id.clone(),
+            to_input_name: edge.to_input_name.clone(),
+        });
+    }
+
+    document.edges.sort_by(|a, b| {
+        (
+            &a.from_node_id,
+            &a.from_output_name,
+            &a.to_node_id,
+            &a.to_input_name,
+        )
+            .cmp(&(
+                &b.from_node_id,
+                &b.from_output_name,
+                &b.to_node_id,
+                &b.to_input_name,
+            ))
+    });
+
+    PasteClipboardFragmentResult {
+        inserted_node_ids: id_map.into_values().collect(),
+        skipped_node_type_ids,
+    }
+}
+
+fn clipboard_fragment_origin(nodes: &[GraphNode]) -> NodePosition {
+    let mut iter = nodes.iter();
+    let Some(first) = iter.next() else {
+        return NodePosition::default();
+    };
+
+    let mut min_x = first.viewport.position.x;
+    let mut min_y = first.viewport.position.y;
+    for node in iter {
+        min_x = min_x.min(node.viewport.position.x);
+        min_y = min_y.min(node.viewport.position.y);
+    }
+
+    NodePosition { x: min_x, y: min_y }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
     use shared::{
-        NodeCategory, NodeConnectionDefinition, ParameterDefaultValue, ParameterUiHint,
-        ParameterVisibilityCondition,
+        GraphMetadata, NodeCategory, NodeConnectionDefinition, NodeParameter,
+        ParameterDefaultValue, ParameterUiHint, ParameterVisibilityCondition,
     };
 
     fn sample_definition() -> NodeDefinition {
@@ -713,5 +849,111 @@ mod tests {
                 .iter()
                 .any(|parameter| parameter.name == "advanced_value")
         );
+    }
+
+    fn test_graph_node(id: &str, node_type: &str, x: f32, y: f32) -> GraphNode {
+        GraphNode {
+            id: id.to_owned(),
+            metadata: NodeMetadata {
+                name: id.to_owned(),
+            },
+            node_type: NodeTypeId::new(node_type.to_owned()),
+            viewport: shared::NodeViewport {
+                position: NodePosition { x, y },
+                collapsed: false,
+            },
+            input_values: Vec::new(),
+            parameters: vec![NodeParameter {
+                name: "example".to_owned(),
+                value: json!(1.0),
+            }],
+        }
+    }
+
+    fn test_graph_document() -> GraphDocument {
+        GraphDocument {
+            metadata: GraphMetadata {
+                id: "graph-a".to_owned(),
+                name: "Graph A".to_owned(),
+                execution_frequency_hz: 60,
+            },
+            viewport: shared::GraphViewport::default(),
+            nodes: vec![
+                test_graph_node("node-a", "test.visibility", 10.0, 20.0),
+                test_graph_node("node-b", "test.visibility", 30.0, 60.0),
+                test_graph_node("node-c", "test.unknown", 90.0, 120.0),
+            ],
+            edges: vec![
+                GraphEdge {
+                    from_node_id: "node-a".to_owned(),
+                    from_output_name: "value".to_owned(),
+                    to_node_id: "node-b".to_owned(),
+                    to_input_name: "value".to_owned(),
+                },
+                GraphEdge {
+                    from_node_id: "node-b".to_owned(),
+                    from_output_name: "value".to_owned(),
+                    to_node_id: "node-c".to_owned(),
+                    to_input_name: "value".to_owned(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn clipboard_fragment_only_keeps_selected_nodes_and_internal_edges() {
+        let document = test_graph_document();
+        let selected_node_ids = ["node-a".to_owned(), "node-b".to_owned()]
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        let fragment =
+            clipboard_fragment_from_document(&document, &selected_node_ids).expect("fragment");
+
+        assert_eq!(fragment.origin, NodePosition { x: 10.0, y: 20.0 });
+        assert_eq!(fragment.nodes.len(), 2);
+        assert_eq!(fragment.edges.len(), 1);
+        assert_eq!(fragment.edges[0].from_node_id, "node-a");
+        assert_eq!(fragment.edges[0].to_node_id, "node-b");
+    }
+
+    #[test]
+    fn paste_clipboard_fragment_remaps_ids_and_skips_unknown_nodes() {
+        let mut destination = GraphDocument {
+            metadata: GraphMetadata {
+                id: "graph-b".to_owned(),
+                name: "Graph B".to_owned(),
+                execution_frequency_hz: 60,
+            },
+            ..GraphDocument::default()
+        };
+        let fragment = GraphClipboardFragment::new(
+            NodePosition { x: 10.0, y: 20.0 },
+            vec![
+                test_graph_node("node-a", "test.visibility", 10.0, 20.0),
+                test_graph_node("node-c", "test.unknown", 90.0, 120.0),
+            ],
+            vec![GraphEdge {
+                from_node_id: "node-a".to_owned(),
+                from_output_name: "value".to_owned(),
+                to_node_id: "node-c".to_owned(),
+                to_input_name: "value".to_owned(),
+            }],
+        );
+
+        let result = paste_clipboard_fragment_into_document(
+            &mut destination,
+            &fragment,
+            &[sample_definition()],
+            Some(NodePosition { x: 50.0, y: 80.0 }),
+        );
+
+        assert_eq!(destination.nodes.len(), 1);
+        assert_eq!(destination.edges.len(), 0);
+        assert_eq!(result.inserted_node_ids.len(), 1);
+        assert_eq!(result.skipped_node_type_ids, vec!["test.unknown"]);
+        assert_eq!(destination.nodes[0].viewport.position.x, 50.0);
+        assert_eq!(destination.nodes[0].viewport.position.y, 80.0);
+        assert_ne!(destination.nodes[0].id, "node-a");
     }
 }

--- a/crates/frontend/src/editor_view/viewer.rs
+++ b/crates/frontend/src/editor_view/viewer.rs
@@ -1,7 +1,10 @@
 use eframe::egui;
 use eframe::egui::emath::TSTransform;
 use eframe::egui::{Popup, PopupCloseBehavior, SetOpenCommand};
-use egui_snarl::ui::{NodeLayout, PinInfo, PinPlacement, SnarlPin, SnarlStyle, SnarlViewer};
+use egui_snarl::ui::{
+    NodeLayout, PinInfo, PinPlacement, SelectionStyle, SnarlPin, SnarlStyle, SnarlViewer,
+    get_selected_nodes,
+};
 use egui_snarl::{InPin, NodeId, OutPin, Snarl};
 use shared::{
     GraphDocument, MqttBrokerConfig, NodeCategory, NodeDefinition, NodeDiagnosticSeverity,
@@ -445,8 +448,8 @@ fn render_graph_menu_contents(
 /// Renders the graph canvas, synchronizes it with the document model, and returns UI side effects.
 ///
 /// The returned tuple carries viewport-application state, diagnostics-panel requests, hover state,
-/// node-menu search text, the next graph-space position for the add-node menu, and any requested
-/// image upload action.
+/// selected nodes, pointer position in graph space, node-menu search text, the next graph-space
+/// position for the add-node menu, and any requested image upload action.
 pub(super) fn show_snarl_canvas(
     ui: &mut egui::Ui,
     mut snarl: &mut Snarl<EditorSnarlNode>,
@@ -464,6 +467,8 @@ pub(super) fn show_snarl_canvas(
     bool,
     Option<String>,
     bool,
+    Vec<String>,
+    Option<egui::Pos2>,
     String,
     Option<egui::Pos2>,
     Option<(String, String)>,
@@ -503,13 +508,22 @@ pub(super) fn show_snarl_canvas(
         crisp_magnified_text: Some(true),
         pin_placement: Some(PinPlacement::Edge),
         header_drag_space: Some([0.0, 0.0].into()),
+        select_style: Some(SelectionStyle {
+            margin: egui::Margin::same(2),
+            rounding: egui::CornerRadius::same(8),
+            fill: egui::Color32::from_rgba_premultiplied(255, 153, 51, 18),
+            stroke: egui::Stroke::new(1.0, egui::Color32::from_rgb(255, 153, 51)),
+        }),
         ..SnarlStyle::new()
     };
+    let mut snarl_widget_id = None;
 
     let canvas_response = ui.allocate_ui_with_layout(
         canvas_size,
         egui::Layout::top_down(egui::Align::Min),
         |ui| {
+            snarl_widget_id =
+                Some(ui.make_persistent_id(format!("graph_snarl_{}", document.metadata.id)));
             snarl.show(
                 &mut viewer,
                 &style,
@@ -518,6 +532,8 @@ pub(super) fn show_snarl_canvas(
             );
         },
     );
+    let snarl_widget_id = snarl_widget_id
+        .unwrap_or_else(|| ui.make_persistent_id(format!("graph_snarl_{}", document.metadata.id)));
     let mut next_node_menu_graph_position = node_menu_graph_position;
     let open_context_menu = viewer.requested_graph_menu_pos.is_some();
     if let Some(menu_pos) = viewer.requested_graph_menu_pos {
@@ -542,20 +558,41 @@ pub(super) fn show_snarl_canvas(
         next_node_menu_graph_position = None;
     }
 
-    sync_document_from_snarl(document, &snarl);
+    let mut pointer_graph_position = None;
     if let Some(transform) = viewer.current_transform {
         document.viewport.zoom = transform.scaling;
         document.viewport.pan.x = transform.translation.x;
         document.viewport.pan.y = transform.translation.y;
+        if let Some(pointer_pos) = ui.ctx().pointer_hover_pos() {
+            pointer_graph_position = Some(screen_to_graph(pointer_pos, transform));
+        }
     }
     let canvas_hovered = ui.rect_contains_pointer(canvas_response.response.rect);
+    let selected_graph_node_ids = get_selected_nodes(snarl_widget_id, ui.ctx())
+        .into_iter()
+        .filter_map(|node_id| {
+            snarl
+                .get_node(node_id)
+                .map(|node| node.graph_node_id.clone())
+        })
+        .collect();
+    sync_document_from_snarl(document, &snarl);
     (
         should_apply_transform,
         viewer.opened_diagnostics_node_id,
         canvas_hovered,
+        selected_graph_node_ids,
+        canvas_hovered.then_some(pointer_graph_position).flatten(),
         viewer.node_menu_search,
         next_node_menu_graph_position,
         viewer.requested_image_upload,
+    )
+}
+
+fn screen_to_graph(pos: egui::Pos2, transform: TSTransform) -> egui::Pos2 {
+    egui::pos2(
+        (pos.x - transform.translation.x) / transform.scaling,
+        (pos.y - transform.translation.y) / transform.scaling,
     )
 }
 

--- a/crates/frontend/src/state.rs
+++ b/crates/frontend/src/state.rs
@@ -36,12 +36,18 @@ pub(crate) struct UiState {
     pub(crate) mqtt_broker_dialog_open: bool,
     pub(crate) mqtt_broker_draft: Vec<MqttBrokerConfig>,
     pub(crate) editor_canvas_hovered: bool,
+    pub(crate) selected_graph_node_ids: Vec<String>,
+    pub(crate) editor_pointer_graph_position: Option<(f32, f32)>,
     pub(crate) node_menu_search: String,
     pub(crate) node_menu_graph_position: Option<(f32, f32)>,
     pub(crate) pending_import_graph_file: Option<GraphExchangeFile>,
     #[cfg(target_arch = "wasm32")]
     pub(crate) browser_graph_file_events:
         Option<mpsc::UnboundedReceiver<crate::browser_file::BrowserGraphFileEvent>>,
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) browser_clipboard_events:
+        Option<mpsc::UnboundedReceiver<crate::browser_file::BrowserClipboardEvent>>,
+    pub(crate) pending_clipboard_read_graph_id: Option<String>,
     #[cfg(target_arch = "wasm32")]
     pub(crate) browser_image_asset_events:
         Option<mpsc::UnboundedReceiver<crate::browser_file::BrowserImageAssetEvent>>,
@@ -66,11 +72,16 @@ impl Default for UiState {
             mqtt_broker_dialog_open: false,
             mqtt_broker_draft: Vec::new(),
             editor_canvas_hovered: false,
+            selected_graph_node_ids: Vec::new(),
+            editor_pointer_graph_position: None,
             node_menu_search: String::new(),
             node_menu_graph_position: None,
             pending_import_graph_file: None,
             #[cfg(target_arch = "wasm32")]
             browser_graph_file_events: None,
+            #[cfg(target_arch = "wasm32")]
+            browser_clipboard_events: None,
+            pending_clipboard_read_graph_id: None,
             #[cfg(target_arch = "wasm32")]
             browser_image_asset_events: None,
         }

--- a/crates/shared/src/graph/exchange.rs
+++ b/crates/shared/src/graph/exchange.rs
@@ -1,10 +1,14 @@
-use super::GraphDocument;
+use super::{GraphDocument, GraphEdge, GraphNode, NodePosition};
 use serde::{Deserialize, Serialize};
 
 /// Stable file-format identifier for exported graph documents.
 pub const GRAPH_EXCHANGE_FORMAT: &str = "animation_builder_graph";
 /// Current version of the single-graph exchange file format.
 pub const GRAPH_EXCHANGE_VERSION: u32 = 1;
+/// Stable clipboard-format identifier for copied graph fragments.
+pub const GRAPH_CLIPBOARD_FRAGMENT_FORMAT: &str = "animation_builder_graph_fragment";
+/// Current version of the clipboard fragment format.
+pub const GRAPH_CLIPBOARD_FRAGMENT_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -21,6 +25,48 @@ pub enum GraphImportCollisionPolicy {
 pub enum GraphImportMode {
     Imported,
     Overwritten,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// Represents the versioned clipboard format for a copied graph fragment.
+pub struct GraphClipboardFragment {
+    pub format: String,
+    pub version: u32,
+    pub origin: NodePosition,
+    #[serde(default)]
+    pub nodes: Vec<GraphNode>,
+    #[serde(default)]
+    pub edges: Vec<GraphEdge>,
+}
+
+impl GraphClipboardFragment {
+    /// Wraps a copied node fragment in the current clipboard header.
+    pub fn new(origin: NodePosition, nodes: Vec<GraphNode>, edges: Vec<GraphEdge>) -> Self {
+        Self {
+            format: GRAPH_CLIPBOARD_FRAGMENT_FORMAT.to_owned(),
+            version: GRAPH_CLIPBOARD_FRAGMENT_VERSION,
+            origin,
+            nodes,
+            edges,
+        }
+    }
+
+    /// Validates that the clipboard header matches the supported format and version.
+    pub fn validate_header(&self) -> Result<(), String> {
+        if self.format != GRAPH_CLIPBOARD_FRAGMENT_FORMAT {
+            return Err(format!(
+                "Unsupported graph clipboard format '{}'",
+                self.format
+            ));
+        }
+        if self.version != GRAPH_CLIPBOARD_FRAGMENT_VERSION {
+            return Err(format!(
+                "Unsupported graph clipboard version {}",
+                self.version
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -61,7 +107,11 @@ impl GraphExchangeFile {
 
 #[cfg(test)]
 mod graph_exchange_tests {
-    use super::{GRAPH_EXCHANGE_FORMAT, GRAPH_EXCHANGE_VERSION, GraphDocument, GraphExchangeFile};
+    use super::{
+        GRAPH_CLIPBOARD_FRAGMENT_FORMAT, GRAPH_CLIPBOARD_FRAGMENT_VERSION, GRAPH_EXCHANGE_FORMAT,
+        GRAPH_EXCHANGE_VERSION, GraphClipboardFragment, GraphDocument, GraphExchangeFile,
+    };
+    use crate::NodePosition;
 
     /// Tests that graph exchange files preserve their contents across JSON serialization.
     #[test]
@@ -102,6 +152,51 @@ mod graph_exchange_tests {
             format!(
                 "Unsupported graph exchange version {}",
                 GRAPH_EXCHANGE_VERSION + 1
+            )
+        );
+    }
+
+    #[test]
+    fn graph_clipboard_fragment_round_trips_through_json() {
+        let fragment =
+            GraphClipboardFragment::new(NodePosition { x: 12.0, y: 34.0 }, Vec::new(), Vec::new());
+        let json = serde_json::to_string(&fragment).expect("serialize graph clipboard fragment");
+        let decoded: GraphClipboardFragment =
+            serde_json::from_str(&json).expect("deserialize graph clipboard fragment");
+        assert_eq!(decoded, fragment);
+    }
+
+    #[test]
+    fn graph_clipboard_fragment_rejects_unknown_format() {
+        let fragment = GraphClipboardFragment {
+            format: "other_format".to_owned(),
+            version: GRAPH_CLIPBOARD_FRAGMENT_VERSION,
+            origin: NodePosition::default(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        };
+
+        assert_eq!(
+            fragment.validate_header().unwrap_err(),
+            "Unsupported graph clipboard format 'other_format'"
+        );
+    }
+
+    #[test]
+    fn graph_clipboard_fragment_rejects_unknown_version() {
+        let fragment = GraphClipboardFragment {
+            format: GRAPH_CLIPBOARD_FRAGMENT_FORMAT.to_owned(),
+            version: GRAPH_CLIPBOARD_FRAGMENT_VERSION + 1,
+            origin: NodePosition::default(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        };
+
+        assert_eq!(
+            fragment.validate_header().unwrap_err(),
+            format!(
+                "Unsupported graph clipboard version {}",
+                GRAPH_CLIPBOARD_FRAGMENT_VERSION + 1
             )
         );
     }

--- a/docs/user/editor.md
+++ b/docs/user/editor.md
@@ -26,6 +26,8 @@ Inside the editor you can:
 - add nodes
 - connect nodes
 - change parameter values
+- select and move multiple nodes together
+- copy and paste selected nodes
 - inspect runtime values for debug-oriented nodes
 - run the graph
 - step or pause the runtime
@@ -41,6 +43,38 @@ The usual graph-editing loop looks like this:
 4. Adjust parameters and defaults.
 5. Start the runtime and inspect the result.
 6. Use diagnostics or debug-oriented nodes when behavior is not what you expect.
+
+## Selection And Clipboard
+
+The editor supports multi-selection on the node canvas.
+
+You can:
+
+- select multiple nodes
+- drag one selected node to move the full selected group
+- copy the selected nodes to the system clipboard
+- paste copied nodes into the current graph
+- copy from one graph or browser window and paste into another
+
+Selection gestures:
+
+- `Shift`+click: add a node to the current selection
+- `Ctrl`+click or `Cmd`+click: remove a node from the current selection
+- `Shift`+drag: box-select multiple nodes
+- `Ctrl`+click or `Cmd`+click on empty canvas space: clear the current selection
+
+When you copy a selection:
+
+- only the selected nodes are included
+- connections between the selected nodes are preserved
+- connections to nodes outside the selection are not copied
+
+When you paste:
+
+- pasted nodes receive fresh node ids
+- copied internal connections are restored
+- the paste location prefers the current canvas pointer position when the canvas is hovered
+- unsupported node types are skipped instead of failing the whole paste
 
 ## Dashboard Actions
 
@@ -65,6 +99,8 @@ When a graph is open, the editor header gives you graph-level controls such as:
 - pause
 - step by a configurable number of ticks
 - stop
+- copy selected nodes
+- paste copied nodes
 - export
 - focus the canvas
 - reload the selected graph from storage
@@ -72,6 +108,15 @@ When a graph is open, the editor header gives you graph-level controls such as:
 - undo and redo
 
 These controls let you move between editing, runtime inspection, and recovery without leaving the graph.
+
+## Keyboard Shortcuts
+
+Useful editor shortcuts:
+
+- `Ctrl+C` or `Cmd+C`: copy the currently selected nodes
+- `Ctrl+V` or `Cmd+V`: paste copied nodes into the open graph
+- `Ctrl+Z` or `Cmd+Z`: undo
+- `Ctrl+Y` or `Cmd+Shift+Z`: redo
 
 ## Imports And Exports
 


### PR DESCRIPTION
## Summary
- add visible multi-node selection support in the editor and expose copy/paste actions plus keyboard shortcuts
- add a shared clipboard fragment format that preserves selected nodes and internal edges while remapping IDs on paste
- read and write graph fragments through the browser clipboard so pastes work across graphs and windows, with paste targeting the initiating graph
- document the new selection and clipboard workflow in the user docs

## Why
The editor was missing standard graph-editing basics called out in issue #26: multi-selection, group movement, and clipboard-based reuse of node fragments across graphs and browser windows.

## Impact
Users can now select multiple nodes, move them together, copy a fragment, and paste it into the same graph or another graph/window. Unsupported node types are skipped during paste instead of breaking the whole operation.

## Root Cause
The editor had no persisted clipboard fragment representation and no integration with `egui_snarl` selection state or the browser clipboard APIs.

## Testing
- `cargo test -p frontend --locked`
- `trunk build --release`

## Notes
- left an unrelated local formatting change in `crates/backend/src/node_runtime/nodes/inputs/image_source.rs` out of this PR on purpose to keep the scope focused

Closes #26