### PR TITLE
chore(nodes): rename node catalog terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Luma Weaver is a Rust workspace for a node-based lighting and animation editor.
 
 - `crates/backend`: Axum HTTP/WebSocket server, graph persistence, runtime executor/compiler, WLED discovery/output, MQTT/Home Assistant integration
 - `crates/frontend`: `egui`/`eframe` WebAssembly UI built with `trunk`
-- `crates/shared`: graph schema, protocol types, validation, and built-in node definitions shared by frontend and backend
+- `crates/shared`: graph schema, protocol types, validation, and node definitions shared by frontend and backend
 
 Runtime shape:
 
@@ -61,6 +61,7 @@ Common commands:
 - Preserve persisted graph compatibility unless the task explicitly allows a breaking change. If you must break compatibility, call it out clearly in the PR notes.
 - Treat `config.yaml`, Docker, and workflow changes as release-sensitive. Keep them minimal and verify carefully.
 - Do not invent new infrastructure or project structure when an existing pattern already exists nearby.
+- Update docs in `docs`
 
 ## Event-Driven TODOs
 
@@ -80,9 +81,9 @@ Use this section as a maintenance checklist. When one of these events happens, e
   - `build.yaml`
   - `repository.yaml`
 
-### If you add, remove, rename, or materially change a built-in node
+### If you add, remove, rename, or materially change a node
 
-- Update the shared node catalog in `crates/shared/src/graph/builtin_nodes.rs`.
+- Update the shared node catalog in `crates/shared/src/graph/node_catalog.rs`.
 - Update or add the backend runtime implementation under `crates/backend/src/node_runtime/nodes/...`.
 - Register the runtime in `crates/backend/src/node_runtime/registry.rs`.
 - Verify the frontend editor picks it up correctly through the shared node definitions, especially:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The workspace is split into three crates:
 
 - `crates/frontend`: the browser UI, built with `eframe`/`egui` and compiled to WebAssembly with `trunk`
 - `crates/backend`: the HTTP/WebSocket server, graph storage, graph runtime, WLED discovery, and MQTT/Home Assistant integration
-- `crates/shared`: shared protocol types, graph schema, validation, and built-in node definitions used by both frontend and backend
+- `crates/shared`: shared protocol types, graph schema, validation, and node definitions used by both frontend and backend
 
 In backend mode, the flow looks like this:
 
@@ -183,6 +183,3 @@ The backend includes:
 ## Status
 
 The project already contains a substantial runtime and node catalog, but it is still evolving. If you deploy it, expect the graph format, node set, and integrations to continue growing.
-
-
-

--- a/crates/backend/src/app/startup.rs
+++ b/crates/backend/src/app/startup.rs
@@ -8,7 +8,7 @@ use tokio::sync::RwLock;
 
 use crate::app::state::AppState;
 use crate::messaging::event_bus::EventBus;
-use crate::node_runtime::build_builtin_node_registry;
+use crate::node_runtime::build_node_registry;
 use crate::services::graph_store::GraphStore;
 use crate::services::image_asset_store::{ImageAssetStore, set_global_image_asset_store};
 use crate::services::mqtt::{HomeAssistantMqttService, set_global_home_assistant_mqtt_service};
@@ -23,7 +23,7 @@ use crate::services::wled::discovery::spawn_wled_discovery_task;
 pub(crate) async fn build_app_state() -> anyhow::Result<AppState> {
     let data_dir = app_data_dir();
     let event_bus = EventBus::default();
-    let node_registry = build_builtin_node_registry()?;
+    let node_registry = build_node_registry()?;
     let graph_store = Arc::new(GraphStore::new(&data_dir, Arc::new(event_bus.clone())));
     let image_asset_store = Arc::new(ImageAssetStore::new(&data_dir)?);
     let mqtt_broker_store = Arc::new(MqttBrokerStore::new(&data_dir));

--- a/crates/backend/src/demo.rs
+++ b/crates/backend/src/demo.rs
@@ -9,7 +9,7 @@ use shared::{
     GraphRuntimeMode, GraphRuntimeStatus, MqttBrokerConfig, NodeDefinition, NodeDiagnostic,
     NodeDiagnosticEntry, NodeDiagnosticSeverity, NodeDiagnosticSummary, NodeExecutionTarget,
     NodeRuntimeUpdateValue, NodeRuntimeValue, ServerMessage, ServerState, WledInstance,
-    builtin_node_definitions, validate_graph_document,
+    node_definitions, validate_graph_document,
 };
 use uuid::Uuid;
 
@@ -67,7 +67,7 @@ impl DemoTransport {
             response_tx,
             node_registry: build_portable_node_registry()
                 .context("build portable node registry")?,
-            node_definitions: builtin_node_definitions()
+            node_definitions: node_definitions()
                 .into_iter()
                 .filter(|definition| {
                     definition.supports_execution_target(NodeExecutionTarget::FrontendDemo)
@@ -699,7 +699,7 @@ fn validate_demo_document(document: &GraphDocument) -> anyhow::Result<()> {
             .join("; ")
     );
     for node in &document.nodes {
-        let supported = builtin_node_definitions()
+        let supported = node_definitions()
             .into_iter()
             .find(|definition| definition.id == node.node_type.as_str())
             .map(|definition| {

--- a/crates/backend/src/node_runtime/mod.rs
+++ b/crates/backend/src/node_runtime/mod.rs
@@ -44,7 +44,7 @@ pub(crate) use macros::{
 pub(crate) use parameters::{ParameterStatus, parameter_status};
 /// Built-in registry construction and lookup.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) use registry::build_builtin_node_registry;
+pub(crate) use registry::build_node_registry;
 pub(crate) use registry::{NodeRegistry, build_portable_node_registry};
 /// Generic serde-based runtime input and output conversion helpers.
 pub(crate) use shared::{AnyInputValue, deserialize_inputs, serialize_outputs};

--- a/crates/backend/src/node_runtime/nodes/generators/bouncing_balls.rs
+++ b/crates/backend/src/node_runtime/nodes/generators/bouncing_balls.rs
@@ -1012,9 +1012,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::node_runtime::{NodeEvaluationContext, RuntimeInputs, RuntimeNode};
-    use shared::{
-        LedLayout, NodeDiagnosticSeverity, NodeTypeId, RgbaColor, builtin_node_definition,
-    };
+    use shared::{LedLayout, NodeDiagnosticSeverity, NodeTypeId, RgbaColor, node_definition};
 
     #[test]
     fn boundary_collision_time_hits_exact_contact() {
@@ -1102,7 +1100,7 @@ mod tests {
 
     #[test]
     fn default_inputs_do_not_trigger_radius_clamp_diagnostics() {
-        let definition = builtin_node_definition(NodeTypeId::BOUNCING_BALLS)
+        let definition = node_definition(NodeTypeId::BOUNCING_BALLS)
             .expect("bouncing balls node definition must exist");
         let radius_default = definition
             .input_port("radius")

--- a/crates/backend/src/node_runtime/nodes/inputs/ha_mqtt_number.rs
+++ b/crates/backend/src/node_runtime/nodes/inputs/ha_mqtt_number.rs
@@ -31,7 +31,7 @@ impl Default for HomeAssistantMqttNumberConfig {
     fn default() -> Self {
         Self {
             broker_id: String::new(),
-            entity_id: "animation_builder_number".to_owned(),
+            entity_id: "luma_weaver_number".to_owned(),
             display_name: "Luma Weaver Number".to_owned(),
             default_value: 0.0,
             min: 0.0,
@@ -44,7 +44,7 @@ impl Default for HomeAssistantMqttNumberConfig {
 
 crate::node_runtime::impl_runtime_parameters!(HomeAssistantMqttNumberConfig {
     broker_id: String => |value| value.trim().to_owned(), default String::new(),
-    entity_id: String => |value| value.trim().to_owned(), default "animation_builder_number".to_owned(),
+    entity_id: String => |value| value.trim().to_owned(), default "luma_weaver_number".to_owned(),
     display_name: String => |value| value.trim().to_owned(), default "Luma Weaver Number".to_owned(),
     default_value: f64 => |value| value as f32, default 0.0f32,
     min: f64 => |value| value as f32, default 0.0f32,

--- a/crates/backend/src/node_runtime/nodes/inputs/image_source.rs
+++ b/crates/backend/src/node_runtime/nodes/inputs/image_source.rs
@@ -252,9 +252,7 @@ fn user_facing_load_error_message(asset_id: &str, error: &anyhow::Error) -> Stri
         return format!("Uploaded image asset '{asset_id}' is missing.");
     }
 
-    if error.to_string().contains("image asset id")
-        && error.to_string().contains("is invalid")
-    {
+    if error.to_string().contains("image asset id") && error.to_string().contains("is invalid") {
         return "Uploaded image reference is invalid.".to_owned();
     }
 
@@ -597,7 +595,9 @@ mod tests {
 
         assert_eq!(message, "Uploaded image asset 'asset-123' is missing.");
         assert!(matches!(
-            error.downcast_ref::<std::io::Error>().map(std::io::Error::kind),
+            error
+                .downcast_ref::<std::io::Error>()
+                .map(std::io::Error::kind),
             Some(ErrorKind::NotFound)
         ));
     }

--- a/crates/backend/src/node_runtime/registry.rs
+++ b/crates/backend/src/node_runtime/registry.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
 use shared::NodeDiagnostic;
-use shared::{NodeDefinition, NodeExecutionTarget, NodeTypeId, builtin_node_definitions};
+use shared::{NodeDefinition, NodeExecutionTarget, NodeTypeId, node_definitions};
 
 use crate::node_runtime::nodes;
 use crate::node_runtime::{
@@ -78,7 +78,7 @@ impl NodeRegistry {
 
     /// Registers a typed runtime node using the fast evaluator path.
     ///
-    /// This is the common path for built-in nodes whose inputs, parameters, and outputs are all
+    /// This is the common path for nodes whose inputs, parameters, and outputs are all
     /// described by the shared node schema.
     pub(crate) fn register_fast_node<T>(&mut self, definition: NodeDefinition) -> anyhow::Result<()>
     where
@@ -126,12 +126,12 @@ impl NodeRegistry {
     }
 }
 
-/// Builds the registry containing all built-in node types.
+/// Builds the registry containing all node types.
 ///
-/// This function pairs the shared built-in node definitions with their backend runtime
+/// This function pairs the shared node definitions with their backend runtime
 /// implementations and returns the result as a shared `Arc`.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn build_builtin_node_registry() -> anyhow::Result<Arc<NodeRegistry>> {
+pub(crate) fn build_node_registry() -> anyhow::Result<Arc<NodeRegistry>> {
     build_registry(NodeExecutionTarget::Backend)
 }
 
@@ -141,202 +141,202 @@ pub(crate) fn build_portable_node_registry() -> anyhow::Result<Arc<NodeRegistry>
 
 fn build_registry(target: NodeExecutionTarget) -> anyhow::Result<Arc<NodeRegistry>> {
     let mut registry = NodeRegistry::new();
-    let definitions_by_id = builtin_node_definitions()
+    let definitions_by_id = node_definitions()
         .into_iter()
         .filter(|definition| definition.supports_execution_target(target))
         .map(|definition| (definition.id.clone(), definition))
         .collect::<HashMap<_, _>>();
 
-    macro_rules! register_builtin {
+    macro_rules! register_node {
         ($node_type:expr, $runtime:ty) => {
             registry.register_fast_node::<$runtime>(
                 definitions_by_id
                     .get($node_type)
                     .cloned()
-                    .expect("builtin node definition must exist"),
+                    .expect("node definition must exist"),
             )?;
         };
     }
 
-    register_builtin!(
+    register_node!(
         NodeTypeId::FLOAT_CONSTANT,
         nodes::inputs::float_constant::FloatConstantNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::COLOR_CONSTANT,
         nodes::inputs::color_constant::ColorConstantNode
     );
-    register_builtin!(NodeTypeId::DELAY, nodes::temporal_filters::delay::DelayNode);
-    register_builtin!(NodeTypeId::DISPLAY, nodes::outputs::display::DisplayNode);
-    register_builtin!(NodeTypeId::PLOT, nodes::outputs::plot::PlotNode);
+    register_node!(NodeTypeId::DELAY, nodes::temporal_filters::delay::DelayNode);
+    register_node!(NodeTypeId::DISPLAY, nodes::outputs::display::DisplayNode);
+    register_node!(NodeTypeId::PLOT, nodes::outputs::plot::PlotNode);
     #[cfg(not(target_arch = "wasm32"))]
     if matches!(target, NodeExecutionTarget::Backend) {
-        register_builtin!(
+        register_node!(
             NodeTypeId::WLED_TARGET,
             nodes::outputs::wled_target::WledTargetNode
         );
-        register_builtin!(
+        register_node!(
             NodeTypeId::WLED_SINK,
             nodes::inputs::wled_sink::WledSinkNode
         );
-        register_builtin!(
+        register_node!(
             NodeTypeId::AUDIO_FFT_RECEIVER,
             nodes::inputs::audio_fft_receiver::AudioFftReceiverNode
         );
-        register_builtin!(
+        register_node!(
             NodeTypeId::IMAGE_SOURCE,
             nodes::inputs::image_source::ImageSourceNode
         );
-        register_builtin!(
+        register_node!(
             NodeTypeId::HA_MQTT_NUMBER,
             nodes::inputs::ha_mqtt_number::HomeAssistantMqttNumberNode
         );
     }
-    register_builtin!(
+    register_node!(
         NodeTypeId::SIGNAL_GENERATOR,
         nodes::inputs::signal_generator::SignalGeneratorNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::BINARY_SELECT,
         nodes::math::binary_select::BinarySelectNode
     );
-    register_builtin!(NodeTypeId::ADD_FLOAT, nodes::math::add_float::AddFloatNode);
-    register_builtin!(
+    register_node!(NodeTypeId::ADD_FLOAT, nodes::math::add_float::AddFloatNode);
+    register_node!(
         NodeTypeId::SUBTRACT_FLOAT,
         nodes::math::subtract_float::SubtractFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::DIVIDE_FLOAT,
         nodes::math::divide_float::DivideFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::MIN_MAX_FLOAT,
         nodes::math::min_max_float::MinMaxFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::MULTIPLY_FLOAT,
         nodes::math::multiply_float::MultiplyFloatNode
     );
-    register_builtin!(NodeTypeId::ABS_FLOAT, nodes::math::abs_float::AbsFloatNode);
-    register_builtin!(
+    register_node!(NodeTypeId::ABS_FLOAT, nodes::math::abs_float::AbsFloatNode);
+    register_node!(
         NodeTypeId::CLAMP_FLOAT,
         nodes::math::clamp_float::ClampFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::POWER_FLOAT,
         nodes::math::power_float::PowerFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::ROOT_FLOAT,
         nodes::math::root_float::RootFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::EXPONENTIAL_FLOAT,
         nodes::math::exponential_float::ExponentialFloatNode
     );
-    register_builtin!(NodeTypeId::LOG_FLOAT, nodes::math::log_float::LogFloatNode);
-    register_builtin!(
+    register_node!(NodeTypeId::LOG_FLOAT, nodes::math::log_float::LogFloatNode);
+    register_node!(
         NodeTypeId::MAP_RANGE_FLOAT,
         nodes::math::map_range_float::MapRangeFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::ROUND_FLOAT,
         nodes::math::round_float::RoundFloatNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::SCALE_TENSOR,
         nodes::math::scale_tensor::ScaleTensorNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::SCALE_COLOR,
         nodes::frame_operations::scale_color::ScaleColorNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::MULTIPLY_COLOR,
         nodes::frame_operations::multiply_color::MultiplyColorNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::TINT_FRAME,
         nodes::frame_operations::tint_frame::TintFrameNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::MASK_FRAME,
         nodes::frame_operations::mask_frame::MaskFrameNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::MIX_COLOR,
         nodes::frame_operations::mix_color::MixColorNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::ALPHA_OVER,
         nodes::frame_operations::alpha_over::AlphaOverNode
     );
-    register_builtin!(NodeTypeId::FADE, nodes::temporal_filters::fade::FadeNode);
-    register_builtin!(
+    register_node!(NodeTypeId::FADE, nodes::temporal_filters::fade::FadeNode);
+    register_node!(
         NodeTypeId::MOVING_AVERAGE,
         nodes::temporal_filters::moving_average::MovingAverageNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::MOVING_MEDIAN,
         nodes::temporal_filters::moving_median::MovingMedianNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::BOX_BLUR,
         nodes::spatial_filters::box_blur::BoxBlurNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::GAUSSIAN_BLUR,
         nodes::spatial_filters::gaussian_blur::GaussianBlurNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::MEDIAN_FILTER,
         nodes::spatial_filters::median_filter::MedianFilterNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::LAPLACIAN_FILTER,
         nodes::spatial_filters::laplacian_filter::LaplacianFilterNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::SPECTRUM_ANALYZER,
         nodes::generators::spectrum_analyzer::SpectrumAnalyzerNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::SOLID_FRAME,
         nodes::generators::solid_frame::SolidFrameNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::RAINBOW_SWEEP,
         nodes::generators::rainbow_sweep::RainbowSweepNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::CIRCLE_SWEEP,
         nodes::generators::circle_sweep::CircleSweepNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::LEVEL_BAR,
         nodes::generators::level_bar::LevelBarNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::BOUNCING_BALLS,
         nodes::generators::bouncing_balls::BouncingBallsNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::TWINKLE_STARS,
         nodes::generators::twinkle_stars::TwinkleStarsNode
     );
-    register_builtin!(NodeTypeId::PLASMA, nodes::generators::plasma::PlasmaNode);
-    register_builtin!(
+    register_node!(NodeTypeId::PLASMA, nodes::generators::plasma::PlasmaNode);
+    register_node!(
         NodeTypeId::FRAME_BRIGHTNESS,
         nodes::frame_operations::frame_brightness::FrameBrightnessNode
     );
-    register_builtin!(
+    register_node!(
         NodeTypeId::WLED_DUMMY_DISPLAY,
         nodes::debug::wled_dummy_display::WledDummyDisplayNode
     );
 
     anyhow::ensure!(
         registry.definition(NodeTypeId::FLOAT_CONSTANT).is_some(),
-        "builtin node registry must contain inputs.float_constant"
+        "node registry must contain inputs.float_constant"
     );
 
     Ok(Arc::new(registry))
@@ -347,10 +347,10 @@ mod tests {
     use std::collections::HashMap;
 
     use serde_json::Value as JsonValue;
-    use shared::{NodeCategory, NodeDefinition, builtin_node_definition};
+    use shared::{NodeCategory, NodeDefinition, node_definition};
 
     use super::{
-        NodeRegistry, RegisteredNodeType, build_builtin_node_registry, build_portable_node_registry,
+        NodeRegistry, RegisteredNodeType, build_node_registry, build_portable_node_registry,
     };
     use crate::node_runtime::{
         NodeEvaluationContext, RuntimeNode, RuntimeNodeEvaluator, RuntimeNodeFromParameters,
@@ -394,9 +394,9 @@ mod tests {
     }
 
     #[test]
-    /// Tests that the built-in registry contains the expected built-in node entries.
-    fn builtin_registry_contains_nodes() {
-        let registry = build_builtin_node_registry().expect("build builtin registry");
+    /// Tests that the node registry contains the expected node entries.
+    fn node_registry_contains_nodes() {
+        let registry = build_node_registry().expect("build node registry");
         assert!(registry.definitions().len() > 10);
         assert!(
             registry
@@ -409,8 +409,8 @@ mod tests {
     /// Tests that registering the same node ID twice returns an error.
     fn duplicate_node_ids_are_rejected() {
         let mut registry = NodeRegistry::new();
-        let definition = builtin_node_definition(shared::NodeTypeId::FLOAT_CONSTANT)
-            .expect("builtin float constant definition");
+        let definition =
+            node_definition(shared::NodeTypeId::FLOAT_CONSTANT).expect("float constant definition");
         registry
             .register(RegisteredNodeType {
                 definition: definition.clone(),
@@ -430,7 +430,7 @@ mod tests {
     }
 
     #[test]
-    /// Tests that custom Rust nodes can be registered through the same API as built-ins.
+    /// Tests that custom Rust nodes can be registered through the same API as catalog nodes.
     fn custom_rust_nodes_register_through_same_api() {
         let mut registry = NodeRegistry::new();
         registry

--- a/crates/backend/src/services/mqtt/mod.rs
+++ b/crates/backend/src/services/mqtt/mod.rs
@@ -342,19 +342,19 @@ mod tests {
 
         assert_eq!(
             discovery_topic(&config, &registration.graph_id, &registration.entity_id),
-            "homeassistant/number/animation_builder/graph_one_number_one/config"
+            "homeassistant/number/luma_weaver/graph_one_number_one/config"
         );
         assert_eq!(
             number_state_topic(&config.id, &registration.graph_id, &registration.entity_id),
-            "animation_builder/primary/graph/graph_one/number/number_one/state"
+            "luma_weaver/primary/graph/graph_one/number/number_one/state"
         );
         assert_eq!(
             number_command_topic(&config.id, &registration.graph_id, &registration.entity_id),
-            "animation_builder/primary/graph/graph_one/number/number_one/set"
+            "luma_weaver/primary/graph/graph_one/number/number_one/set"
         );
         assert_eq!(
             device_identifier(&registration.graph_id),
-            "animation_builder_graph_graph_one"
+            "luma_weaver_graph_graph_one"
         );
         assert_eq!(
             entity_object_id(&registration.graph_id, &registration.entity_id),
@@ -362,7 +362,7 @@ mod tests {
         );
         assert_eq!(
             entity_unique_id(&config.id, &registration.graph_id, &registration.entity_id),
-            "animation_builder_primary_graph_one_number_one"
+            "luma_weaver_primary_graph_one_number_one"
         );
     }
 
@@ -764,7 +764,7 @@ fn update_connected(
 /// Returns the Home Assistant discovery topic for a number entity.
 fn discovery_topic(config: &MqttBrokerConfig, graph_id: &str, entity_id: &str) -> String {
     format!(
-        "{}/number/animation_builder/{}/config",
+        "{}/number/luma_weaver/{}/config",
         config.discovery_prefix.trim().trim_end_matches('/'),
         entity_object_id(graph_id, entity_id)
     )
@@ -773,7 +773,7 @@ fn discovery_topic(config: &MqttBrokerConfig, graph_id: &str, entity_id: &str) -
 /// Returns the MQTT state topic for a Home Assistant number entity.
 fn number_state_topic(broker_id: &str, graph_id: &str, entity_id: &str) -> String {
     format!(
-        "animation_builder/{}/graph/{}/number/{}/state",
+        "luma_weaver/{}/graph/{}/number/{}/state",
         sanitize_identifier(broker_id),
         sanitize_identifier(graph_id),
         sanitize_identifier(entity_id)
@@ -783,7 +783,7 @@ fn number_state_topic(broker_id: &str, graph_id: &str, entity_id: &str) -> Strin
 /// Returns the MQTT command topic for a Home Assistant number entity.
 fn number_command_topic(broker_id: &str, graph_id: &str, entity_id: &str) -> String {
     format!(
-        "animation_builder/{}/graph/{}/number/{}/set",
+        "luma_weaver/{}/graph/{}/number/{}/set",
         sanitize_identifier(broker_id),
         sanitize_identifier(graph_id),
         sanitize_identifier(entity_id)
@@ -793,14 +793,14 @@ fn number_command_topic(broker_id: &str, graph_id: &str, entity_id: &str) -> Str
 /// Returns the MQTT availability topic for a broker connection.
 fn broker_availability_topic(broker_id: &str) -> String {
     format!(
-        "animation_builder/{}/availability",
+        "luma_weaver/{}/availability",
         sanitize_identifier(broker_id)
     )
 }
 
 /// Returns the stable Home Assistant device identifier for a graph-backed entity set.
 fn device_identifier(graph_id: &str) -> String {
-    format!("animation_builder_graph_{}", sanitize_identifier(graph_id))
+    format!("luma_weaver_graph_{}", sanitize_identifier(graph_id))
 }
 
 /// Returns the stable Home Assistant object ID for one number entity within a graph.
@@ -815,7 +815,7 @@ fn entity_object_id(graph_id: &str, entity_id: &str) -> String {
 /// Returns the stable Home Assistant unique ID for one graph-backed entity.
 fn entity_unique_id(broker_id: &str, graph_id: &str, entity_id: &str) -> String {
     format!(
-        "animation_builder_{}_{}_{}",
+        "luma_weaver_{}_{}_{}",
         sanitize_identifier(broker_id),
         sanitize_identifier(graph_id),
         sanitize_identifier(entity_id),
@@ -845,7 +845,7 @@ fn sanitize_identifier(value: &str) -> String {
         }
     }
     if output.is_empty() {
-        "animation_builder".to_owned()
+        "luma_weaver".to_owned()
     } else {
         output
     }

--- a/crates/backend/src/services/runtime/compiler.rs
+++ b/crates/backend/src/services/runtime/compiler.rs
@@ -206,11 +206,11 @@ fn topological_order(adjacency: &[Vec<usize>], in_degree: &[usize]) -> anyhow::R
 
 #[cfg(test)]
 mod tests {
-    use crate::node_runtime::{NodeEvaluationContext, build_builtin_node_registry};
+    use crate::node_runtime::{NodeEvaluationContext, build_node_registry};
     use crate::services::runtime::compiler::compile_graph_document;
     use shared::{
         GraphDocument, GraphMetadata, GraphNode, LedLayout, NodeMetadata, NodeTypeId,
-        ParameterDefaultValue, builtin_node_definition,
+        ParameterDefaultValue, node_definition,
     };
 
     /// Tests that parameter-normalization diagnostics are preserved on compiled nodes.
@@ -239,7 +239,7 @@ mod tests {
         }))
         .expect("parse graph");
 
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let compiled = compile_graph_document(document, node_registry).expect("compile graph");
         let diagnostics = &compiled.nodes[0].construction_diagnostics;
 
@@ -279,7 +279,7 @@ mod tests {
         }))
         .expect("parse unknown node graph");
 
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let error = match compile_graph_document(document, node_registry) {
             Ok(_) => panic!("unknown node type should fail"),
             Err(error) => error,
@@ -287,11 +287,11 @@ mod tests {
         assert!(error.to_string().contains("Unknown node type"));
     }
 
-    /// Audits every built-in node using schema defaults and fails if any default configuration
+    /// Audits every node using schema defaults and fails if any default configuration
     /// immediately triggers clamp diagnostics.
     #[test]
-    fn builtin_defaults_do_not_emit_clamp_diagnostics() {
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+    fn node_defaults_do_not_emit_clamp_diagnostics() {
+        let node_registry = build_node_registry().expect("build node registry");
         let context = NodeEvaluationContext {
             graph_id: "default-audit-graph".to_owned(),
             graph_name: "Default Audit Graph".to_owned(),
@@ -368,14 +368,14 @@ mod tests {
 
         assert!(
             clamp_findings.is_empty(),
-            "built-in defaults emitted clamp diagnostics:\n{}",
+            "node defaults emitted clamp diagnostics:\n{}",
             clamp_findings.join("\n")
         );
     }
 
     #[test]
     fn frame_brightness_default_factor_is_neutral() {
-        let definition = builtin_node_definition(NodeTypeId::FRAME_BRIGHTNESS)
+        let definition = node_definition(NodeTypeId::FRAME_BRIGHTNESS)
             .expect("frame brightness node definition must exist");
         let factor = definition
             .input_port("factor")
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn spectrum_analyzer_schema_exposes_decay_parameter() {
-        let definition = builtin_node_definition(NodeTypeId::SPECTRUM_ANALYZER)
+        let definition = node_definition(NodeTypeId::SPECTRUM_ANALYZER)
             .expect("spectrum analyzer node definition must exist");
         let decay = definition
             .parameter("decay")

--- a/crates/backend/src/services/runtime/executor.rs
+++ b/crates/backend/src/services/runtime/executor.rs
@@ -287,7 +287,7 @@ mod tests {
     use anyhow::Context;
     use shared::{GraphDocument, InputValue};
 
-    use crate::node_runtime::{NodeEvaluationContext, build_builtin_node_registry};
+    use crate::node_runtime::{NodeEvaluationContext, build_node_registry};
     use crate::services::runtime::compiler::compile_graph_document;
     use crate::services::runtime::executor::{evaluate_node, initialize_delay_previous_outputs};
     use crate::services::runtime::types::{GraphExecutionState, RuntimeEventPublisher};
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn sample_runtime_graph_executes_one_tick() {
         let document = sample_runtime_graph();
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let mut graph =
             compile_graph_document(document, node_registry).expect("compile graph document");
         let mut execution_state = GraphExecutionState::default();
@@ -472,13 +472,18 @@ mod tests {
         }))
         .expect("parse binary select graph");
 
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let mut graph =
             compile_graph_document(document, node_registry).expect("compile binary select graph");
         let mut execution_state = GraphExecutionState::default();
 
         graph
-            .execute_tick("binary-select-sample", &NoopEvents, 0.0, &mut execution_state)
+            .execute_tick(
+                "binary-select-sample",
+                &NoopEvents,
+                0.0,
+                &mut execution_state,
+            )
             .expect("execute binary select graph tick");
 
         let selected = execution_state
@@ -493,7 +498,7 @@ mod tests {
     #[test]
     fn sample_runtime_graph_tick_timing() {
         let document = sample_runtime_graph();
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let mut graph =
             compile_graph_document(document, node_registry).expect("compile graph document");
         let mut execution_state = GraphExecutionState::default();
@@ -530,7 +535,7 @@ mod tests {
         const DEFAULT_CONTEXT_ID: &str = "__default__";
 
         let document = sample_runtime_graph();
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let mut graph =
             compile_graph_document(document, node_registry).expect("compile graph document");
         let mut execution_state = GraphExecutionState::default();
@@ -728,7 +733,7 @@ mod tests {
         }))
         .expect("parse delay cycle graph");
 
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let mut graph =
             compile_graph_document(document, node_registry).expect("compile delay cycle graph");
         let mut execution_state = GraphExecutionState::default();
@@ -800,7 +805,7 @@ mod tests {
             ]
         }))
         .expect("parse delay frame seed graph");
-        let node_registry = build_builtin_node_registry().expect("build builtin node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let graph = compile_graph_document(document, node_registry)
             .expect("compile delay frame seed graph");
         let mut execution_state = GraphExecutionState::default();

--- a/crates/backend/src/services/runtime/manager.rs
+++ b/crates/backend/src/services/runtime/manager.rs
@@ -585,7 +585,7 @@ mod tests {
     use shared::{GraphRuntimeStatus, NodeDiagnostic, NodeRuntimeValue};
 
     use super::emit_startup_compile_diagnostics;
-    use crate::node_runtime::build_builtin_node_registry;
+    use crate::node_runtime::build_node_registry;
     use crate::services::runtime::types::RuntimeEventPublisher;
 
     #[derive(Default)]
@@ -636,7 +636,7 @@ mod tests {
             "edges": []
         }))
         .expect("parse graph");
-        let node_registry = build_builtin_node_registry().expect("build node registry");
+        let node_registry = build_node_registry().expect("build node registry");
         let events = RecordingEvents::default();
 
         emit_startup_compile_diagnostics(&document, node_registry.as_ref(), &events);

--- a/crates/frontend/src/editor_view.rs
+++ b/crates/frontend/src/editor_view.rs
@@ -46,9 +46,7 @@ pub(crate) use self::model::{
 };
 
 #[cfg(test)]
-pub(crate) fn snarl_node_titles(
-    snarl: &egui_snarl::Snarl<EditorSnarlNode>,
-) -> Vec<String> {
+pub(crate) fn snarl_node_titles(snarl: &egui_snarl::Snarl<EditorSnarlNode>) -> Vec<String> {
     snarl.nodes().map(|node| node.title.clone()).collect()
 }
 

--- a/crates/shared/src/graph.rs
+++ b/crates/shared/src/graph.rs
@@ -1,11 +1,11 @@
-mod builtin_nodes;
 mod document;
 mod exchange;
+mod node_catalog;
 mod node_definition;
 mod value;
 
-pub use builtin_nodes::*;
 pub use document::*;
 pub use exchange::*;
+pub use node_catalog::*;
 pub use node_definition::*;
 pub use value::*;

--- a/crates/shared/src/graph/exchange.rs
+++ b/crates/shared/src/graph/exchange.rs
@@ -2,7 +2,7 @@ use super::GraphDocument;
 use serde::{Deserialize, Serialize};
 
 /// Stable file-format identifier for exported graph documents.
-pub const GRAPH_EXCHANGE_FORMAT: &str = "animation_builder_graph";
+pub const GRAPH_EXCHANGE_FORMAT: &str = "luma_weaver_graph";
 /// Current version of the single-graph exchange file format.
 pub const GRAPH_EXCHANGE_VERSION: u32 = 1;
 

--- a/crates/shared/src/graph/node_catalog.rs
+++ b/crates/shared/src/graph/node_catalog.rs
@@ -7,7 +7,7 @@ use super::{
 use serde_json::json;
 use std::sync::LazyLock;
 
-/// Returns the canonical opaque-white default input value used by the built-in catalog.
+/// Returns the canonical opaque-white default input value used by the node catalog.
 fn white_input() -> InputValue {
     InputValue::Color(RgbaColor {
         r: 1.0,
@@ -17,7 +17,7 @@ fn white_input() -> InputValue {
     })
 }
 
-/// Returns the canonical fully transparent color used by the built-in catalog.
+/// Returns the canonical fully transparent color used by the node catalog.
 fn transparent_input() -> InputValue {
     InputValue::Color(RgbaColor {
         r: 0.0,
@@ -27,7 +27,7 @@ fn transparent_input() -> InputValue {
     })
 }
 
-/// Returns the canonical single-element zero tensor used by the built-in catalog.
+/// Returns the canonical single-element zero tensor used by the node catalog.
 fn default_tensor_input() -> InputValue {
     InputValue::FloatTensor(FloatTensor {
         shape: vec![1],
@@ -35,7 +35,7 @@ fn default_tensor_input() -> InputValue {
     })
 }
 
-/// Converts a snake_case field name into the title-cased label used by built-in schema definitions.
+/// Converts a snake_case field name into the title-cased label used by node schema definitions.
 fn title_case_name(name: &str) -> String {
     name.split('_')
         .filter(|part| !part.is_empty())
@@ -54,7 +54,7 @@ fn title_case_name(name: &str) -> String {
         .join(" ")
 }
 
-/// Enumerates the waveform options exposed by the built-in signal generator node.
+/// Enumerates the waveform options exposed by the signal generator node.
 static SIGNAL_GENERATOR_WAVEFORMS: LazyLock<Vec<EnumOption>> = LazyLock::new(|| {
     vec![
         EnumOption {
@@ -534,7 +534,7 @@ static HA_MQTT_NUMBER_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| Nod
         NodeParameterDefinition::new(
             "entity_id",
             title_case_name("entity_id"),
-            ParameterDefaultValue::String("animation_builder_number".to_owned()),
+            ParameterDefaultValue::String("luma_weaver_number".to_owned()),
             ParameterUiHint::TextSingleLine,
         ),
         NodeParameterDefinition::new(
@@ -2188,11 +2188,11 @@ static FRAME_BRIGHTNESS_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| N
     runtime_updates: None,
 });
 
-/// Returns the full shared schema catalog for all built-in node types.
+/// Returns the full shared schema catalog for all node types.
 ///
 /// Each call clones the lazily initialized static node definitions into a fresh vector so callers
 /// can freely sort or modify their local copy.
-pub fn builtin_node_definitions() -> Vec<NodeDefinition> {
+pub fn node_definitions() -> Vec<NodeDefinition> {
     vec![
         (*FLOAT_CONSTANT_NODE_TYPE).clone(),
         (*COLOR_CONSTANT_NODE_TYPE).clone(),
@@ -2246,9 +2246,9 @@ pub fn builtin_node_definitions() -> Vec<NodeDefinition> {
     ]
 }
 
-/// Returns the built-in node definition for the requested node type identifier, if it exists.
-pub fn builtin_node_definition(node_type_id: &str) -> Option<NodeDefinition> {
-    builtin_node_definitions()
+/// Returns the node definition for the requested node type identifier, if it exists.
+pub fn node_definition(node_type_id: &str) -> Option<NodeDefinition> {
+    node_definitions()
         .into_iter()
         .find(|definition| definition.id == node_type_id)
 }

--- a/crates/shared/src/graph/node_definition.rs
+++ b/crates/shared/src/graph/node_definition.rs
@@ -393,7 +393,7 @@ pub enum ParameterUiHint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::builtin_node_definition;
+    use crate::node_definition;
     use serde_json::json;
 
     #[test]
@@ -502,28 +502,28 @@ mod tests {
     }
 
     #[test]
-    fn builtin_needs_io_marks_backend_only_nodes() {
+    fn node_catalog_marks_backend_only_nodes() {
         assert!(
-            builtin_node_definition(NodeTypeId::AUDIO_FFT_RECEIVER)
+            node_definition(NodeTypeId::AUDIO_FFT_RECEIVER)
                 .expect("audio fft receiver definition")
                 .needs_io
         );
         assert!(
-            builtin_node_definition(NodeTypeId::WLED_TARGET)
+            node_definition(NodeTypeId::WLED_TARGET)
                 .expect("wled target definition")
                 .needs_io
         );
     }
 
     #[test]
-    fn builtin_needs_io_marks_portable_nodes() {
+    fn node_catalog_marks_portable_nodes() {
         assert!(
-            !builtin_node_definition(NodeTypeId::PLOT)
+            !node_definition(NodeTypeId::PLOT)
                 .expect("plot definition")
                 .needs_io
         );
         assert!(
-            !builtin_node_definition(NodeTypeId::WLED_DUMMY_DISPLAY)
+            !node_definition(NodeTypeId::WLED_DUMMY_DISPLAY)
                 .expect("wled dummy display definition")
                 .needs_io
         );

--- a/crates/shared/src/validation.rs
+++ b/crates/shared/src/validation.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::graph::{GraphDocument, builtin_node_definition};
+use crate::graph::{GraphDocument, node_definition};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Describes one validation problem found while checking a persisted graph document.
@@ -25,7 +25,7 @@ pub enum GraphValidationIssueCode {
     EdgeTypeMismatch,
 }
 
-/// Validates a graph document against the shared built-in node catalog.
+/// Validates a graph document against the shared node catalog.
 ///
 /// Validation checks node identity, declared input values, edge endpoints, and type compatibility.
 /// All discovered issues are returned at once so callers can show a complete error list.
@@ -45,7 +45,7 @@ pub fn validate_graph_document(document: &GraphDocument) -> Vec<GraphValidationI
         }
         nodes_by_id.insert(node.id.clone(), node);
 
-        let Some(definition) = builtin_node_definition(node.node_type.as_str()) else {
+        let Some(definition) = node_definition(node.node_type.as_str()) else {
             issues.push(GraphValidationIssue {
                 code: GraphValidationIssueCode::UnknownNodeType,
                 path: format!("{node_path}.node_type"),
@@ -112,7 +112,7 @@ pub fn validate_graph_document(document: &GraphDocument) -> Vec<GraphValidationI
             continue;
         };
 
-        let Some(from_definition) = builtin_node_definition(from_node.node_type.as_str()) else {
+        let Some(from_definition) = node_definition(from_node.node_type.as_str()) else {
             issues.push(GraphValidationIssue {
                 code: GraphValidationIssueCode::UnknownNodeType,
                 path: format!("{edge_path}.from_node_id"),
@@ -124,7 +124,7 @@ pub fn validate_graph_document(document: &GraphDocument) -> Vec<GraphValidationI
             });
             continue;
         };
-        let Some(to_definition) = builtin_node_definition(to_node.node_type.as_str()) else {
+        let Some(to_definition) = node_definition(to_node.node_type.as_str()) else {
             issues.push(GraphValidationIssue {
                 code: GraphValidationIssueCode::UnknownNodeType,
                 path: format!("{edge_path}.to_node_id"),

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -14,7 +14,7 @@ The Rust workspace is split into three crates:
 
 - `crates/backend`: Axum server, WebSocket API, graph persistence, runtime execution, WLED and MQTT services
 - `crates/frontend`: `egui`/`eframe` browser UI compiled to WebAssembly with `trunk`
-- `crates/shared`: graph schema, protocol types, validation, and built-in node definitions shared by frontend and backend
+- `crates/shared`: graph schema, protocol types, validation, and node definitions shared by frontend and backend
 
 Top-level deployment and packaging files:
 
@@ -65,14 +65,14 @@ Important shared areas:
 
 - `crates/shared/src/protocol.rs`: frontend/backend WebSocket contract
 - `crates/shared/src/graph/node_definition.rs`: node schema types, categories, parameter UI hints
-- `crates/shared/src/graph/builtin_nodes.rs`: built-in node catalog
+- `crates/shared/src/graph/node_catalog.rs`: node catalog
 - `crates/shared/src/validation.rs`: graph validation against shared schema
 
 ## Node System
 
-Each built-in node spans multiple layers:
+Each node spans multiple layers:
 
-1. Shared schema definition in `crates/shared/src/graph/builtin_nodes.rs`
+1. Shared schema definition in `crates/shared/src/graph/node_catalog.rs`
 2. Backend runtime implementation under `crates/backend/src/node_runtime/nodes/...`
 3. Registry entry in `crates/backend/src/node_runtime/registry.rs`
 4. Frontend editor behavior driven from shared definitions and rendered in `crates/frontend/src/editor_view/...`

--- a/docs/developer/backend-objects.md
+++ b/docs/developer/backend-objects.md
@@ -106,7 +106,7 @@ That means both the graph store and the runtime manager can report changes witho
 
 The node registry is built once at startup and shared through `Arc`.
 
-It is the runtime/schema lookup object for built-in nodes. Other backend objects use it to:
+It is the runtime/schema lookup object for the shared node catalog. Other backend objects use it to:
 
 - resolve node definitions
 - create runtime evaluators

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -8,7 +8,7 @@ Use this page as the developer entry point.
 - If you want to understand backend service ownership, read [backend-objects.md](backend-objects.md).
 - If you want to change protocol, subscriptions, or WebSocket behavior, read [protocol-runtime.md](protocol-runtime.md).
 - If you want to change graph compilation or runtime execution, read [runtime-execution.md](runtime-execution.md).
-- If you want to add or change built-in nodes, read [node-authoring.md](node-authoring.md).
+- If you want to add or change nodes, read [node-authoring.md](node-authoring.md).
 - If you want to understand CI, releases, or publishing, read [workflows.md](workflows.md).
 
 ## Source Of Truth
@@ -29,7 +29,7 @@ Use these files together:
 - `backend-objects.md`: long-lived backend service instances, ownership, and process-wide relationships
 - `protocol-runtime.md`: frontend/backend messaging, subscriptions, and transport routing
 - `runtime-execution.md`: graph compilation, render contexts, tick execution, runtime manager behavior
-- `node-authoring.md`: built-in node lifecycle across shared schema, backend runtime, registry, and editor
+- `node-authoring.md`: node lifecycle across shared schema, backend runtime, registry, and editor
 - `workflows.md`: CI, Docker/release validation, add-on publishing, and Pages publishing
 
 ## Git Workflow

--- a/docs/developer/node-authoring.md
+++ b/docs/developer/node-authoring.md
@@ -1,6 +1,6 @@
 # Node Authoring
 
-This page describes the normal workflow for adding or changing built-in nodes in `luma-weaver`.
+This page describes the normal workflow for adding or changing nodes in `luma-weaver`.
 
 Keep this page focused on node lifecycle work.
 
@@ -9,7 +9,7 @@ Keep this page focused on node lifecycle work.
 
 ## Mental Model
 
-A built-in node is not implemented in just one place.
+A node is not implemented in just one place.
 
 Most node changes require coordinated updates in:
 
@@ -25,7 +25,7 @@ Most node changes require coordinated updates in:
 Shared schema:
 
 - `crates/shared/src/graph/node_definition.rs`
-- `crates/shared/src/graph/builtin_nodes.rs`
+- `crates/shared/src/graph/node_catalog.rs`
 
 Backend runtime:
 
@@ -38,12 +38,12 @@ Frontend editor:
 - `crates/frontend/src/editor_view/model.rs`
 - `crates/frontend/src/editor_view/widgets.rs`
 
-## Add A New Built-In Node
+## Add A New Node
 
 Typical sequence:
 
 1. Add or reuse a `NodeTypeId` when needed.
-2. Add the node definition to `crates/shared/src/graph/builtin_nodes.rs`.
+2. Add the node definition to `crates/shared/src/graph/node_catalog.rs`.
 3. Implement the runtime node in the appropriate backend module.
 4. Register it in `crates/backend/src/node_runtime/registry.rs`.
 5. Verify the frontend add-menu placement and parameter rendering.
@@ -63,7 +63,7 @@ Review all of these before finishing:
 
 If the node is renamed, removed, or materially reworked, also review unknown-node and graph migration implications.
 
-Built-in node IDs should use the same category prefix as the add-menu taxonomy and backend module
+Node IDs should use the same category prefix as the add-menu taxonomy and backend module
 layout, for example:
 
 - `inputs.*`

--- a/docs/developer/protocol-runtime.md
+++ b/docs/developer/protocol-runtime.md
@@ -57,7 +57,7 @@ This exists so the Pages preview can stay close to the real app without becoming
 
 ## Structured Protocol
 
-The shared protocol in [protocol.rs](c:/Users/Hannes/repos/animation-builder-rust.worktrees/gundula/crates/shared/src/protocol.rs) is centered around two tagged enums:
+The shared protocol in [protocol.rs](c:/Users/Hannes/repos/luma-weaver.worktrees/hermann/crates/shared/src/protocol.rs) is centered around two tagged enums:
 
 - `ClientMessage`: requests and commands sent by the frontend
 - `ServerMessage`: responses, snapshots, and streamed updates sent back to the frontend

--- a/docs/user/node-catalog.md
+++ b/docs/user/node-catalog.md
@@ -1,6 +1,6 @@
 # Node Catalog Overview
 
-This page gives a user-facing overview of the built-in node families currently present in Luma Weaver.
+This page gives a user-facing overview of the node families currently present in Luma Weaver.
 
 It is not intended to replace source-level schema definitions. Instead, it helps users understand the kinds of nodes available when building graphs.
 

--- a/examples/Example.animation-graph.json
+++ b/examples/Example.animation-graph.json
@@ -1,5 +1,5 @@
 {
-  "format": "animation_builder_graph",
+  "format": "luma_weaver_graph",
   "version": 1,
   "document": {
     "metadata": {


### PR DESCRIPTION
## Summary
- replace misleading built-in/custom wording in contributor and user-facing docs with plain `node` terminology
- rename the internal shared node catalog API from `builtin_*` to `node_*`
- rename remaining `animation_builder*` identifiers to `luma_weaver*` in graph exchange metadata, MQTT topics/IDs, defaults, and the example graph

## Why
Issue #32 calls out that the current built-in/custom distinction is misleading for the current product model. This change aligns the docs and internal API with the simpler mental model that these are just nodes.

## Testing
- `cargo fmt --all`
- `cargo test -p shared -p backend --locked`

## Compatibility Notes
- the shared node catalog file moved from `crates/shared/src/graph/builtin_nodes.rs` to `crates/shared/src/graph/node_catalog.rs`
- the exported graph exchange format identifier changed from `animation_builder_graph` to `luma_weaver_graph`
- Home Assistant / MQTT topic prefixes, device identifiers, and default number entity IDs changed from `animation_builder*` to `luma_weaver*`

Closes #32