### PR TITLE
feat(filters): add differentiate and integrate nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Current building blocks include:
 - animation and pattern nodes such as linear sweep, circle sweep, plasma, twinkle stars, bouncing balls, and level bar
 - math and signal nodes such as constants, add/subtract/multiply/divide, min/max/clamp, abs, map range, binary select, power/root/exp/log, rounding, and signal generator
 - frame and color processing nodes such as tint, mix, blur, Laplacian edge/detail filtering, mask, brightness, and filters
+- temporal nodes such as delay, differentiate, integrate, fade, moving average, and moving median
 - runtime/debug nodes such as plot, display, and a WLED dummy display
 - network nodes for WLED output, WLED frame input, audio FFT receive, and Home Assistant MQTT numbers
 

--- a/crates/backend/src/node_runtime/nodes/temporal_filters/differentiate.rs
+++ b/crates/backend/src/node_runtime/nodes/temporal_filters/differentiate.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+
+use crate::node_runtime::{
+    NodeEvaluationContext, RuntimeNode, RuntimeNodeFromParameters, TypedNodeEvaluation,
+};
+
+#[derive(Default)]
+pub(crate) struct DifferentiateNode {
+    last_elapsed_seconds: Option<f64>,
+    last_value: Option<f32>,
+}
+
+impl RuntimeNodeFromParameters for DifferentiateNode {}
+
+pub(crate) struct DifferentiateInputs {
+    value: f32,
+}
+
+crate::node_runtime::impl_runtime_inputs!(DifferentiateInputs {
+    value = 0.0,
+});
+
+pub(crate) struct DifferentiateOutputs {
+    value: f32,
+}
+
+crate::node_runtime::impl_runtime_outputs!(DifferentiateOutputs { value });
+
+impl RuntimeNode for DifferentiateNode {
+    type Inputs = DifferentiateInputs;
+    type Outputs = DifferentiateOutputs;
+
+    /// Differentiates the input against elapsed runtime seconds.
+    fn evaluate(
+        &mut self,
+        context: &NodeEvaluationContext,
+        inputs: Self::Inputs,
+    ) -> Result<TypedNodeEvaluation<Self::Outputs>> {
+        let output = match (self.last_value, self.last_elapsed_seconds) {
+            (Some(previous_value), Some(previous_time))
+                if context.elapsed_seconds >= previous_time =>
+            {
+                let dt = (context.elapsed_seconds - previous_time) as f32;
+                if dt > 0.0 {
+                    (inputs.value - previous_value) / dt
+                } else {
+                    0.0
+                }
+            }
+            _ => 0.0,
+        };
+
+        self.last_value = Some(inputs.value);
+        self.last_elapsed_seconds = Some(context.elapsed_seconds);
+
+        Ok(TypedNodeEvaluation::from_outputs(DifferentiateOutputs {
+            value: output,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::node_runtime::{NodeEvaluationContext, RuntimeNode};
+
+    use super::{DifferentiateInputs, DifferentiateNode};
+
+    fn context(elapsed_seconds: f64) -> NodeEvaluationContext {
+        NodeEvaluationContext {
+            graph_id: "test-graph".to_owned(),
+            graph_name: "Test Graph".to_owned(),
+            elapsed_seconds,
+            render_layout: None,
+        }
+    }
+
+    #[test]
+    fn first_sample_outputs_zero() {
+        let mut node = DifferentiateNode::default();
+
+        let evaluation = node
+            .evaluate(&context(0.0), DifferentiateInputs { value: 4.0 })
+            .expect("evaluate first sample");
+
+        assert_eq!(evaluation.outputs.value, 0.0);
+    }
+
+    #[test]
+    fn computes_rate_of_change_from_elapsed_seconds() {
+        let mut node = DifferentiateNode::default();
+
+        node.evaluate(&context(0.0), DifferentiateInputs { value: 1.0 })
+            .expect("prime differentiate");
+        let evaluation = node
+            .evaluate(&context(0.5), DifferentiateInputs { value: 2.0 })
+            .expect("differentiate ramp");
+
+        assert_eq!(evaluation.outputs.value, 2.0);
+    }
+
+    #[test]
+    fn returns_zero_when_time_does_not_advance() {
+        let mut node = DifferentiateNode::default();
+
+        node.evaluate(&context(1.0), DifferentiateInputs { value: 1.0 })
+            .expect("prime differentiate");
+        let evaluation = node
+            .evaluate(&context(1.0), DifferentiateInputs { value: 3.0 })
+            .expect("differentiate repeated timestamp");
+
+        assert_eq!(evaluation.outputs.value, 0.0);
+    }
+}

--- a/crates/backend/src/node_runtime/nodes/temporal_filters/integrate.rs
+++ b/crates/backend/src/node_runtime/nodes/temporal_filters/integrate.rs
@@ -1,0 +1,458 @@
+use std::collections::HashMap;
+
+use anyhow::{Result, bail};
+use serde_json::Value as JsonValue;
+use shared::{
+    ColorFrame, FloatTensor, InputValue, NodeDiagnostic, NodeDiagnosticSeverity, RgbaColor,
+};
+
+use crate::node_runtime::{
+    AnyInputValue, NodeConstruction, NodeEvaluationContext, RuntimeNode, RuntimeNodeFromParameters,
+    TypedNodeEvaluation,
+};
+
+#[derive(Default)]
+pub(crate) struct IntegrateNode {
+    initial_value: f32,
+    clamp_output: bool,
+    min: f32,
+    max: f32,
+    accumulated: Option<InputValue>,
+    initialized: bool,
+    last_elapsed_seconds: Option<f64>,
+}
+
+#[derive(Default)]
+struct IntegrateParameters {
+    initial_value: f32,
+    clamp_output: bool,
+    min: f32,
+    max: f32,
+}
+
+crate::node_runtime::impl_runtime_parameters!(IntegrateParameters {
+    initial_value: f64 => |value| value as f32, default 0.0f32,
+    clamp_output: bool = false,
+    min: f64 => |value| value as f32, default -1.0f32,
+    max: f64 => |value| value as f32, default 1.0f32,
+});
+
+impl IntegrateNode {
+    fn from_config(config: IntegrateParameters) -> (Self, Vec<NodeDiagnostic>) {
+        let mut diagnostics = Vec::new();
+        let (min, max) = if config.clamp_output && config.min > config.max {
+            diagnostics.push(NodeDiagnostic {
+                severity: NodeDiagnosticSeverity::Warning,
+                code: Some("integrate_bounds_swapped".to_owned()),
+                message: "Integrate min exceeded max, so the bounds were swapped.".to_owned(),
+            });
+            (config.max, config.min)
+        } else {
+            (config.min, config.max)
+        };
+
+        let node = Self {
+            initial_value: config.initial_value,
+            clamp_output: config.clamp_output,
+            min,
+            max,
+            accumulated: None,
+            initialized: false,
+            last_elapsed_seconds: None,
+        };
+        (node, diagnostics)
+    }
+
+    fn clamp_scalar(&self, value: f32) -> f32 {
+        if self.clamp_output {
+            value.clamp(self.min, self.max)
+        } else {
+            value
+        }
+    }
+
+    fn reset_state(&mut self, elapsed_seconds: f64, rate: &InputValue) {
+        self.accumulated = Some(self.initial_state(rate));
+        self.initialized = true;
+        self.last_elapsed_seconds = Some(elapsed_seconds);
+    }
+
+    fn initial_state(&self, rate: &InputValue) -> InputValue {
+        match rate {
+            InputValue::Float(_) => InputValue::Float(self.clamp_scalar(self.initial_value)),
+            InputValue::FloatTensor(tensor) => InputValue::FloatTensor(FloatTensor {
+                shape: tensor.shape.clone(),
+                values: vec![self.clamp_scalar(self.initial_value); tensor.values.len()],
+            }),
+            InputValue::ColorFrame(frame) => InputValue::ColorFrame(ColorFrame {
+                layout: frame.layout.clone(),
+                pixels: vec![
+                    RgbaColor {
+                        r: self.clamp_scalar(self.initial_value),
+                        g: self.clamp_scalar(self.initial_value),
+                        b: self.clamp_scalar(self.initial_value),
+                        a: self.clamp_scalar(self.initial_value),
+                    };
+                    frame.pixels.len()
+                ],
+            }),
+            other => panic!("unsupported integrate input kind: {:?}", other.value_kind()),
+        }
+    }
+
+    fn integrate_step(
+        &self,
+        accumulated: &InputValue,
+        rate: &InputValue,
+        dt: f32,
+    ) -> Result<InputValue> {
+        match (accumulated, rate) {
+            (InputValue::Float(accumulated), InputValue::Float(rate)) => Ok(InputValue::Float(
+                self.clamp_scalar(*accumulated + *rate * dt),
+            )),
+            (InputValue::FloatTensor(accumulated), InputValue::FloatTensor(rate)) => {
+                if accumulated.shape != rate.shape || accumulated.values.len() != rate.values.len()
+                {
+                    bail!("integrate tensor shape mismatch");
+                }
+                Ok(InputValue::FloatTensor(FloatTensor {
+                    shape: accumulated.shape.clone(),
+                    values: accumulated
+                        .values
+                        .iter()
+                        .zip(rate.values.iter())
+                        .map(|(accumulated, rate)| self.clamp_scalar(*accumulated + *rate * dt))
+                        .collect(),
+                }))
+            }
+            (InputValue::ColorFrame(accumulated), InputValue::ColorFrame(rate)) => {
+                if accumulated.layout != rate.layout
+                    || accumulated.pixels.len() != rate.pixels.len()
+                {
+                    bail!("integrate frame layout mismatch");
+                }
+                Ok(InputValue::ColorFrame(ColorFrame {
+                    layout: accumulated.layout.clone(),
+                    pixels: accumulated
+                        .pixels
+                        .iter()
+                        .zip(rate.pixels.iter())
+                        .map(|(accumulated, rate)| RgbaColor {
+                            r: self.clamp_scalar(accumulated.r + rate.r * dt),
+                            g: self.clamp_scalar(accumulated.g + rate.g * dt),
+                            b: self.clamp_scalar(accumulated.b + rate.b * dt),
+                            a: self.clamp_scalar(accumulated.a + rate.a * dt),
+                        })
+                        .collect(),
+                }))
+            }
+            _ => bail!("integrate input kind changed between evaluations"),
+        }
+    }
+}
+
+impl RuntimeNodeFromParameters for IntegrateNode {
+    fn from_parameters(parameters: &HashMap<String, JsonValue>) -> NodeConstruction<Self> {
+        let NodeConstruction {
+            node: config,
+            diagnostics,
+        } = IntegrateParameters::from_parameters(parameters);
+        let (node, mut extra_diagnostics) = Self::from_config(config);
+        let mut diagnostics = diagnostics;
+        diagnostics.append(&mut extra_diagnostics);
+        NodeConstruction { node, diagnostics }
+    }
+}
+
+pub(crate) struct IntegrateInputs {
+    rate: AnyInputValue,
+    reset: f32,
+}
+
+crate::node_runtime::impl_runtime_inputs!(IntegrateInputs {
+    rate = AnyInputValue(InputValue::Float(0.0)),
+    reset = 0.0,
+});
+
+pub(crate) struct IntegrateOutputs {
+    value: InputValue,
+}
+
+crate::node_runtime::impl_runtime_outputs!(IntegrateOutputs { value });
+
+impl RuntimeNode for IntegrateNode {
+    type Inputs = IntegrateInputs;
+    type Outputs = IntegrateOutputs;
+
+    /// Integrates the input rate against elapsed runtime seconds using explicit Euler steps.
+    fn evaluate(
+        &mut self,
+        context: &NodeEvaluationContext,
+        inputs: Self::Inputs,
+    ) -> Result<TypedNodeEvaluation<Self::Outputs>> {
+        let rate = inputs.rate.0;
+        if inputs.reset >= 0.5 {
+            self.reset_state(context.elapsed_seconds, &rate);
+            return Ok(TypedNodeEvaluation::from_outputs(IntegrateOutputs {
+                value: self
+                    .accumulated
+                    .clone()
+                    .expect("integrate reset must initialize state"),
+            }));
+        }
+
+        if !self.initialized {
+            self.reset_state(context.elapsed_seconds, &rate);
+            return Ok(TypedNodeEvaluation::from_outputs(IntegrateOutputs {
+                value: self
+                    .accumulated
+                    .clone()
+                    .expect("integrate initialization must set state"),
+            }));
+        }
+
+        let dt = match self.last_elapsed_seconds {
+            Some(previous_time) if context.elapsed_seconds >= previous_time => {
+                (context.elapsed_seconds - previous_time) as f32
+            }
+            _ => 0.0,
+        };
+        self.last_elapsed_seconds = Some(context.elapsed_seconds);
+
+        if dt > 0.0 {
+            let accumulated = self
+                .accumulated
+                .as_ref()
+                .expect("integrate must have initialized state before stepping");
+            self.accumulated = Some(self.integrate_step(accumulated, &rate, dt)?);
+        }
+
+        Ok(TypedNodeEvaluation::from_outputs(IntegrateOutputs {
+            value: self
+                .accumulated
+                .clone()
+                .expect("integrate must have state when emitting output"),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shared::{ColorFrame, FloatTensor, InputValue, LedLayout, RgbaColor};
+
+    use crate::node_runtime::{AnyInputValue, NodeEvaluationContext, RuntimeNode};
+
+    use super::{IntegrateInputs, IntegrateNode};
+
+    fn context(elapsed_seconds: f64) -> NodeEvaluationContext {
+        NodeEvaluationContext {
+            graph_id: "test-graph".to_owned(),
+            graph_name: "Test Graph".to_owned(),
+            elapsed_seconds,
+            render_layout: None,
+        }
+    }
+
+    #[test]
+    fn first_sample_outputs_initial_value() {
+        let mut node = IntegrateNode::default();
+
+        let evaluation = node
+            .evaluate(
+                &context(0.0),
+                IntegrateInputs {
+                    rate: AnyInputValue(InputValue::Float(3.0)),
+                    reset: 0.0,
+                },
+            )
+            .expect("evaluate initial integrate sample");
+
+        assert_eq!(evaluation.outputs.value, InputValue::Float(0.0));
+    }
+
+    #[test]
+    fn accumulates_rate_over_elapsed_seconds() {
+        let mut node = IntegrateNode::default();
+
+        node.evaluate(
+            &context(0.0),
+            IntegrateInputs {
+                rate: AnyInputValue(InputValue::Float(2.0)),
+                reset: 0.0,
+            },
+        )
+        .expect("prime integrate");
+        let evaluation = node
+            .evaluate(
+                &context(0.5),
+                IntegrateInputs {
+                    rate: AnyInputValue(InputValue::Float(2.0)),
+                    reset: 0.0,
+                },
+            )
+            .expect("integrate half second");
+
+        assert_eq!(evaluation.outputs.value, InputValue::Float(1.0));
+    }
+
+    #[test]
+    fn reset_restores_initial_value() {
+        let mut node = IntegrateNode {
+            initial_value: 5.0,
+            ..IntegrateNode::default()
+        };
+
+        node.evaluate(
+            &context(0.0),
+            IntegrateInputs {
+                rate: AnyInputValue(InputValue::Float(1.0)),
+                reset: 0.0,
+            },
+        )
+        .expect("prime integrate");
+        node.evaluate(
+            &context(1.0),
+            IntegrateInputs {
+                rate: AnyInputValue(InputValue::Float(1.0)),
+                reset: 0.0,
+            },
+        )
+        .expect("integrate one second");
+        let evaluation = node
+            .evaluate(
+                &context(2.0),
+                IntegrateInputs {
+                    rate: AnyInputValue(InputValue::Float(1.0)),
+                    reset: 1.0,
+                },
+            )
+            .expect("reset integrate");
+
+        assert_eq!(evaluation.outputs.value, InputValue::Float(5.0));
+    }
+
+    #[test]
+    fn clamps_when_enabled() {
+        let mut node = IntegrateNode {
+            clamp_output: true,
+            min: -1.0,
+            max: 1.0,
+            ..IntegrateNode::default()
+        };
+
+        node.evaluate(
+            &context(0.0),
+            IntegrateInputs {
+                rate: AnyInputValue(InputValue::Float(10.0)),
+                reset: 0.0,
+            },
+        )
+        .expect("prime integrate");
+        let evaluation = node
+            .evaluate(
+                &context(1.0),
+                IntegrateInputs {
+                    rate: AnyInputValue(InputValue::Float(10.0)),
+                    reset: 0.0,
+                },
+            )
+            .expect("integrate clamped");
+
+        assert_eq!(evaluation.outputs.value, InputValue::Float(1.0));
+    }
+
+    #[test]
+    fn integrates_float_tensors_elementwise() {
+        let mut node = IntegrateNode::default();
+
+        node.evaluate(
+            &context(0.0),
+            IntegrateInputs {
+                rate: AnyInputValue(InputValue::FloatTensor(FloatTensor {
+                    shape: vec![2],
+                    values: vec![2.0, -4.0],
+                })),
+                reset: 0.0,
+            },
+        )
+        .expect("prime tensor integrate");
+        let evaluation = node
+            .evaluate(
+                &context(0.5),
+                IntegrateInputs {
+                    rate: AnyInputValue(InputValue::FloatTensor(FloatTensor {
+                        shape: vec![2],
+                        values: vec![2.0, -4.0],
+                    })),
+                    reset: 0.0,
+                },
+            )
+            .expect("integrate tensor");
+
+        assert_eq!(
+            evaluation.outputs.value,
+            InputValue::FloatTensor(FloatTensor {
+                shape: vec![2],
+                values: vec![1.0, -2.0],
+            })
+        );
+    }
+
+    #[test]
+    fn integrates_color_frames_per_channel() {
+        let mut node = IntegrateNode::default();
+        let layout = LedLayout {
+            id: "layout".to_owned(),
+            pixel_count: 1,
+            width: Some(1),
+            height: Some(1),
+        };
+
+        node.evaluate(
+            &context(0.0),
+            IntegrateInputs {
+                rate: AnyInputValue(InputValue::ColorFrame(ColorFrame {
+                    layout: layout.clone(),
+                    pixels: vec![RgbaColor {
+                        r: 2.0,
+                        g: 0.0,
+                        b: -2.0,
+                        a: 1.0,
+                    }],
+                })),
+                reset: 0.0,
+            },
+        )
+        .expect("prime frame integrate");
+        let evaluation = node
+            .evaluate(
+                &context(0.25),
+                IntegrateInputs {
+                    rate: AnyInputValue(InputValue::ColorFrame(ColorFrame {
+                        layout: layout.clone(),
+                        pixels: vec![RgbaColor {
+                            r: 2.0,
+                            g: 0.0,
+                            b: -2.0,
+                            a: 1.0,
+                        }],
+                    })),
+                    reset: 0.0,
+                },
+            )
+            .expect("integrate frame");
+
+        assert_eq!(
+            evaluation.outputs.value,
+            InputValue::ColorFrame(ColorFrame {
+                layout,
+                pixels: vec![RgbaColor {
+                    r: 0.5,
+                    g: 0.0,
+                    b: -0.5,
+                    a: 0.25,
+                }],
+            })
+        );
+    }
+}

--- a/crates/backend/src/node_runtime/nodes/temporal_filters/mod.rs
+++ b/crates/backend/src/node_runtime/nodes/temporal_filters/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod delay;
+pub(crate) mod differentiate;
 pub(crate) mod fade;
+pub(crate) mod integrate;
 pub(crate) mod moving_average;
 pub(crate) mod moving_median;

--- a/crates/backend/src/node_runtime/registry.rs
+++ b/crates/backend/src/node_runtime/registry.rs
@@ -167,6 +167,10 @@ fn build_registry(target: NodeExecutionTarget) -> anyhow::Result<Arc<NodeRegistr
         nodes::inputs::color_constant::ColorConstantNode
     );
     register_builtin!(NodeTypeId::DELAY, nodes::temporal_filters::delay::DelayNode);
+    register_builtin!(
+        NodeTypeId::DIFFERENTIATE,
+        nodes::temporal_filters::differentiate::DifferentiateNode
+    );
     register_builtin!(NodeTypeId::DISPLAY, nodes::outputs::display::DisplayNode);
     register_builtin!(NodeTypeId::PLOT, nodes::outputs::plot::PlotNode);
     #[cfg(not(target_arch = "wasm32"))]
@@ -272,6 +276,10 @@ fn build_registry(target: NodeExecutionTarget) -> anyhow::Result<Arc<NodeRegistr
         nodes::frame_operations::alpha_over::AlphaOverNode
     );
     register_builtin!(NodeTypeId::FADE, nodes::temporal_filters::fade::FadeNode);
+    register_builtin!(
+        NodeTypeId::INTEGRATE,
+        nodes::temporal_filters::integrate::IntegrateNode
+    );
     register_builtin!(
         NodeTypeId::MOVING_AVERAGE,
         nodes::temporal_filters::moving_average::MovingAverageNode

--- a/crates/shared/src/graph/builtin_nodes.rs
+++ b/crates/shared/src/graph/builtin_nodes.rs
@@ -336,6 +336,32 @@ static DELAY_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefiniti
     runtime_updates: None,
 });
 
+static DIFFERENTIATE_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
+    id: NodeTypeId::DIFFERENTIATE.to_owned(),
+    display_name: "Differentiate".to_owned(),
+    category: NodeCategory::TemporalFilters,
+    needs_io: false,
+    inputs: vec![NodeInputDefinition {
+        name: "value".to_owned(),
+        display_name: title_case_name("value"),
+        value_kind: ValueKind::Float,
+        accepted_kinds: vec![],
+        default_value: Some(InputValue::Float(0.0)),
+    }],
+    outputs: vec![NodeOutputDefinition {
+        name: "value".to_owned(),
+        display_name: title_case_name("value"),
+        value_kind: ValueKind::Float,
+        accepted_kinds: vec![],
+    }],
+    parameters: vec![],
+    connection: NodeConnectionDefinition {
+        max_input_connections: 1,
+        require_value_kind_match: true,
+    },
+    runtime_updates: None,
+});
+
 static WLED_TARGET_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
     id: NodeTypeId::WLED_TARGET.to_owned(),
     display_name: "Wled Target".to_owned(),
@@ -1455,6 +1481,94 @@ static FADE_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinitio
     runtime_updates: None,
 });
 
+static INTEGRATE_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
+    id: NodeTypeId::INTEGRATE.to_owned(),
+    display_name: "Integrate".to_owned(),
+    category: NodeCategory::TemporalFilters,
+    needs_io: false,
+    inputs: vec![
+        NodeInputDefinition {
+            name: "rate".to_owned(),
+            display_name: title_case_name("rate"),
+            value_kind: ValueKind::Any,
+            accepted_kinds: vec![
+                ValueKind::Float,
+                ValueKind::FloatTensor,
+                ValueKind::ColorFrame,
+            ],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+        NodeInputDefinition {
+            name: "reset".to_owned(),
+            display_name: title_case_name("reset"),
+            value_kind: ValueKind::Float,
+            accepted_kinds: vec![],
+            default_value: Some(InputValue::Float(0.0)),
+        },
+    ],
+    outputs: vec![NodeOutputDefinition {
+        name: "value".to_owned(),
+        display_name: title_case_name("value"),
+        value_kind: ValueKind::Any,
+        accepted_kinds: vec![
+            ValueKind::Float,
+            ValueKind::FloatTensor,
+            ValueKind::ColorFrame,
+        ],
+    }],
+    parameters: vec![
+        NodeParameterDefinition::new(
+            "initial_value",
+            title_case_name("initial_value"),
+            ParameterDefaultValue::Float(0.0),
+            ParameterUiHint::DragFloat {
+                speed: 0.01,
+                min: -10_000.0,
+                max: 10_000.0,
+            },
+        ),
+        NodeParameterDefinition::new(
+            "clamp_output",
+            title_case_name("clamp_output"),
+            ParameterDefaultValue::Bool(false),
+            ParameterUiHint::Checkbox,
+        ),
+        NodeParameterDefinition::new(
+            "min",
+            title_case_name("min"),
+            ParameterDefaultValue::Float(-1.0),
+            ParameterUiHint::DragFloat {
+                speed: 0.01,
+                min: -10_000.0,
+                max: 10_000.0,
+            },
+        )
+        .visible_when(ParameterVisibilityCondition::Equals {
+            parameter: "clamp_output".to_owned(),
+            value: json!(true),
+        }),
+        NodeParameterDefinition::new(
+            "max",
+            title_case_name("max"),
+            ParameterDefaultValue::Float(1.0),
+            ParameterUiHint::DragFloat {
+                speed: 0.01,
+                min: -10_000.0,
+                max: 10_000.0,
+            },
+        )
+        .visible_when(ParameterVisibilityCondition::Equals {
+            parameter: "clamp_output".to_owned(),
+            value: json!(true),
+        }),
+    ],
+    connection: NodeConnectionDefinition {
+        max_input_connections: 1,
+        require_value_kind_match: true,
+    },
+    runtime_updates: None,
+});
+
 static MOVING_AVERAGE_NODE_TYPE: LazyLock<NodeDefinition> = LazyLock::new(|| NodeDefinition {
     id: NodeTypeId::MOVING_AVERAGE.to_owned(),
     display_name: "Moving Average".to_owned(),
@@ -2200,6 +2314,7 @@ pub fn builtin_node_definitions() -> Vec<NodeDefinition> {
         (*DISPLAY_NODE_TYPE).clone(),
         (*PLOT_NODE_TYPE).clone(),
         (*DELAY_NODE_TYPE).clone(),
+        (*DIFFERENTIATE_NODE_TYPE).clone(),
         (*WLED_TARGET_NODE_TYPE).clone(),
         (*WLED_SINK_NODE_TYPE).clone(),
         (*AUDIO_FFT_RECEIVER_NODE_TYPE).clone(),
@@ -2227,6 +2342,7 @@ pub fn builtin_node_definitions() -> Vec<NodeDefinition> {
         (*MIX_COLOR_NODE_TYPE).clone(),
         (*ALPHA_OVER_NODE_TYPE).clone(),
         (*FADE_NODE_TYPE).clone(),
+        (*INTEGRATE_NODE_TYPE).clone(),
         (*MOVING_AVERAGE_NODE_TYPE).clone(),
         (*MOVING_MEDIAN_NODE_TYPE).clone(),
         (*BOX_BLUR_NODE_TYPE).clone(),

--- a/crates/shared/src/graph/node_definition.rs
+++ b/crates/shared/src/graph/node_definition.rs
@@ -18,6 +18,7 @@ impl NodeTypeId {
     pub const DISPLAY: &'static str = "outputs.display";
     pub const PLOT: &'static str = "outputs.plot";
     pub const DELAY: &'static str = "temporal_filters.delay";
+    pub const DIFFERENTIATE: &'static str = "temporal_filters.differentiate";
     pub const WLED_TARGET: &'static str = "outputs.wled_target";
     pub const WLED_SINK: &'static str = "inputs.wled_sink";
     pub const AUDIO_FFT_RECEIVER: &'static str = "inputs.audio_fft_receiver";
@@ -45,6 +46,7 @@ impl NodeTypeId {
     pub const MIX_COLOR: &'static str = "frame_operations.mix";
     pub const ALPHA_OVER: &'static str = "frame_operations.alpha_over";
     pub const FADE: &'static str = "temporal_filters.fade";
+    pub const INTEGRATE: &'static str = "temporal_filters.integrate";
     pub const MOVING_AVERAGE: &'static str = "temporal_filters.moving_average";
     pub const MOVING_MEDIAN: &'static str = "temporal_filters.moving_median";
     pub const BOX_BLUR: &'static str = "spatial_filters.box_blur";

--- a/docs/user/node-catalog.md
+++ b/docs/user/node-catalog.md
@@ -75,11 +75,13 @@ These nodes work across time.
 Examples:
 
 - Delay
+- Differentiate
+- Integrate
 - Fade
 - Moving Average
 - Moving Median
 
-Use these when you want smoothing, trailing, or history-aware behavior.
+Use these when you want smoothing, trailing, accumulation, or other history-aware behavior.
 
 ## Spatial Filters
 


### PR DESCRIPTION
## Summary
- add new `Differentiate` and `Integrate` temporal filter nodes
- implement `Differentiate` using elapsed-time-based rate-of-change semantics with defined first-sample behavior
- implement `Integrate` using explicit Euler integration over elapsed time for `Float`, `FloatTensor`, and `ColorFrame`
- document the new temporal nodes in the README and user node catalog

## Why
This adds the missing temporal signal primitives needed for time-dependent graph logic and makes it practical to build ODE- and PDE-style update graphs with explicit state handling.

## Behavior Notes
- `Differentiate` outputs `0.0` on the first sample and when time does not advance
- `Integrate` preserves internal state, supports `initial_value`, `reset`, and optional output clamping
- `Integrate` does **not** break graph cycles implicitly; `Delay` remains the explicit cycle-breaking node for feedback loops

## Testing
- `cargo fmt --all`
- `cargo test -p shared -p backend --locked`

## Compatibility Notes
- adds new node types `temporal_filters.differentiate` and `temporal_filters.integrate`
- no persisted-graph breaking changes to existing nodes

Closes #18