### PR TITLE
fix(frontend): use wasm-safe clock in demo mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ tracing-wasm = "0.2"
 uuid = { version = "1.18", features = ["v4"] }
 wasm-bindgen = "0.2"
 web-sys = "0.3"
+web-time = "1.1"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -23,6 +23,7 @@ futures-channel.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["js"] }
+web-time.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum.workspace = true

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -16,6 +16,7 @@ pub mod demo;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod messaging;
 pub mod node_runtime;
+mod platform_time;
 pub mod services;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/backend/src/node_runtime/nodes/inputs/image_source.rs
+++ b/crates/backend/src/node_runtime/nodes/inputs/image_source.rs
@@ -6,8 +6,9 @@ use resvg::{
 };
 use shared::{ColorFrame, LedLayout, NodeDiagnostic, NodeDiagnosticSeverity, RgbaColor};
 use std::io::ErrorKind;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use crate::platform_time::Instant;
 use crate::node_runtime::{NodeEvaluationContext, RuntimeNode, TypedNodeEvaluation};
 use crate::services::image_asset_store::global_image_asset_store;
 use crate::services::image_codec::parse_svg;

--- a/crates/backend/src/platform_time.rs
+++ b/crates/backend/src/platform_time.rs
@@ -1,0 +1,6 @@
+pub(crate) use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+pub(crate) use web_time::Instant;

--- a/crates/backend/src/services/runtime/executor.rs
+++ b/crates/backend/src/services/runtime/executor.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use shared::{InputValue, NodeDiagnostic, NodeDiagnosticSeverity, NodeRuntimeValue};
 
 use crate::node_runtime::nodes::temporal_filters::delay::seeded_initial_value_for_layout;
 use crate::node_runtime::{NodeEvaluation, NodeEvaluationContext, RuntimeNodeEvaluator};
+use crate::platform_time::{Duration, Instant};
 use crate::services::runtime::types::{CompiledGraph, GraphExecutionState, RuntimeEventPublisher};
 
 impl CompiledGraph {

--- a/crates/backend/src/services/runtime/types.rs
+++ b/crates/backend/src/services/runtime/types.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Instant;
 
 use serde_json::Value as JsonValue;
 use shared::{
     GraphRuntimeStatus, InputValue, LedLayout, NodeDiagnostic, NodeRuntimeValue, NodeTypeId,
 };
 
+use crate::platform_time::Instant;
 use crate::node_runtime::NodeRegistry;
 use crate::node_runtime::RuntimeNodeEvaluator;
 


### PR DESCRIPTION
## Summary
- add a small backend platform-time shim so the wasm demo build uses a browser-safe `Instant`
- switch demo-reachable runtime code to use that shim instead of `std::time::Instant`
- keep the native backend behavior unchanged while fixing frontend-only demo mode

## Why
Running the frontend in demo mode compiles the in-process demo backend into wasm. That runtime still called `std::time::Instant::now()`, which panics in the browser with `time not implemented on this platform`.

## Impact
The frontend-only demo path should no longer panic on startup when the runtime ticks or image-source retry logic touches wall-clock timing.

## Testing
- `cargo test -p backend --locked`
- `cargo check -p frontend --target wasm32-unknown-unknown --features demo-mode`
