### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/.github/workflows/publish-addon.yml
+++ b/.github/workflows/publish-addon.yml
@@ -11,9 +11,35 @@ permissions:
   packages: write
 
 jobs:
+  validate-release-ref:
+    name: Validate release ref
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require release tag to point at main
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          git fetch origin main
+
+          tag_commit="$(git rev-list -n 1 "${GITHUB_REF_NAME}")"
+          main_commit="$(git rev-parse origin/main)"
+
+          if [[ "${tag_commit}" != "${main_commit}" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} points at ${tag_commit}, but origin/main is ${main_commit}" >&2
+            echo "Merge the release PR to main first, then recreate and push the tag from main." >&2
+            exit 1
+          fi
+
   publish-platform:
     name: Publish ${{ matrix.arch }} image
     runs-on: ubuntu-latest
+    needs: validate-release-ref
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.2.0
+
+### Breaking Changes
+
+- Aligned built-in node IDs with the current node taxonomy. Persisted graphs using the previous built-in node IDs may need migration.
+- Added audio FFT receiver modes with updated audio input behavior.
+
+### Features
+
+- Added WLED UDP raw input support.
+- Reworked the node add-menu hierarchy.
+- Added Home Assistant broker flags and graph-scoped Home Assistant MQTT number grouping.
+- Added conditional visibility for node parameters.
+- Expanded float math, tensor, frame, and filter node workflows.
+- Added moving median, differentiate, integrate, Laplacian, binary select, uploaded image source, and disable-input node capabilities.
+- Added selection clipboard support in the graph editor.
+- Added browser demo mode and GitHub Pages publishing for the frontend preview.
+- Added tensor filter workflows and the PDE heat/wave example graph.
+
+### Fixes
+
+- Improved long one-dimensional frame previews and frame input layout stability.
+- Surfaced runtime diagnostics from the dashboard.
+- Restored GitHub Pages deep links.
+- Fixed frontend clock handling for WebAssembly demo mode.
+- Kept color gradient stops independently editable.
+
+### Documentation And Maintenance
+
+- Added repository guidance for coding agents.
+- Scaffolded audience-based documentation and published docs/reference pages.
+- Improved CI, Docker cache reuse, cargo-chef planning, frontend rustdoc builds, and release note automation.
+- Renamed node catalog terminology and aligned backend node directories with menu categories.
+
 ## 0.1.0
 
 - Initial Home Assistant add-on packaging.

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: "Luma Weaver"
-version: "0.1.0"
+version: "0.2.0"
 slug: "luma_weaver"
 description: "Browser-based node editor for animated lighting with a Rust backend and WebAssembly frontend."
 url: "https://github.com/Hannes-Beckmann/luma-weaver"


### PR DESCRIPTION
## Summary

- bump the Home Assistant add-on version in `config.yaml` to `0.2.0`
- add the `0.2.0` changelog entry with breaking changes, features, fixes, and maintenance notes
- require publish tags to point at the current `origin/main` tip before add-on publishing runs

## Why

This makes the release flow reviewable: merge the release PR first, then create and push `v0.2.0` from the merged `main` commit. The publish workflow now rejects tags that are pushed from an unmerged branch.

## Testing

- Not run locally; release metadata and workflow-only change.

## Compatibility

- Release notes call out breaking graph/node behavior changes since `0.1.0`.
- Publishing `v0.2.0` still requires the tag version to match `config.yaml`.