### PR TITLE
feat(mqtt): add Home Assistant graph controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Luma Weaver is a node-based lighting and animation editor built with Rust. It co
   <img src="assets/example.gif" alt="Luma Weaver editor demo" width="900" />
 </p>
 
-Luma Weaver is designed for programmable LED workflows and reactive visuals, with built-in support for WLED discovery/output and Home Assistant MQTT number entities.
+Luma Weaver is designed for programmable LED workflows and reactive visuals, with built-in support for WLED discovery/output and Home Assistant MQTT graph controls and number entities.
 
 ## Start Here
 
@@ -40,7 +40,7 @@ Current building blocks include:
 - frame and color processing nodes such as tint, mix, blur, Laplacian edge/detail filtering, mask, brightness, and filters
 - temporal nodes such as delay, differentiate, integrate, fade, moving average, and moving median
 - runtime/debug nodes such as plot, display, and a WLED dummy display
-- network nodes for WLED output, WLED frame input, audio FFT receive, and Home Assistant MQTT numbers
+- network nodes for WLED output, WLED frame input, audio FFT receive, and Home Assistant MQTT graph controls/numbers
 
 The editor also supports multi-select graph editing with node-group dragging plus clipboard copy and paste via `Ctrl/Cmd+C` and `Ctrl/Cmd+V`.
 

--- a/crates/backend/src/api/websocket/routing.rs
+++ b/crates/backend/src/api/websocket/routing.rs
@@ -69,6 +69,7 @@ pub(crate) async fn handle_client_message(
                 | ClientMessage::UpdateGraphName { .. }
                 | ClientMessage::ImportGraphDocument { .. }
                 | ClientMessage::UpdateGraphExecutionFrequency { .. }
+                | ClientMessage::UpdateGraphHomeAssistantBroker { .. }
                 | ClientMessage::GetNodeDefinitions
                 | ClientMessage::GetGraphMetadata => {
                     graphs::handle(&mut context, client_message).await
@@ -127,6 +128,9 @@ fn client_message_kind(message: &ClientMessage) -> &'static str {
         ClientMessage::UpdateGraphName { .. } => "update_graph_name",
         ClientMessage::ImportGraphDocument { .. } => "import_graph_document",
         ClientMessage::UpdateGraphExecutionFrequency { .. } => "update_graph_execution_frequency",
+        ClientMessage::UpdateGraphHomeAssistantBroker { .. } => {
+            "update_graph_home_assistant_broker"
+        }
         ClientMessage::GetNodeDefinitions => "get_node_definitions",
         ClientMessage::GetGraphMetadata => "get_graph_metadata",
         ClientMessage::StartGraph { .. } => "start_graph",

--- a/crates/backend/src/api/websocket/routing/graphs.rs
+++ b/crates/backend/src/api/websocket/routing/graphs.rs
@@ -227,6 +227,38 @@ pub(super) async fn handle(
                 }
             }
         }
+        ClientMessage::UpdateGraphHomeAssistantBroker { id, broker_id: _ }
+            if id.trim().is_empty() =>
+        {
+            Some(ServerMessage::Error {
+                message: "Graph document id must not be empty".to_owned(),
+            })
+        }
+        ClientMessage::UpdateGraphHomeAssistantBroker { id, broker_id } => {
+            let id = id.trim().to_owned();
+            match context
+                .state
+                .graph_store
+                .update_home_assistant_broker(&id, broker_id)
+                .await
+            {
+                Ok(true) => None,
+                Ok(false) => Some(ServerMessage::Error {
+                    message: format!("Graph document {id} does not exist"),
+                }),
+                Err(error) => {
+                    tracing::error!(
+                        client_id = context.client_id,
+                        %error,
+                        %id,
+                        "failed to update graph Home Assistant broker"
+                    );
+                    Some(ServerMessage::Error {
+                        message: format!("Failed to update graph Home Assistant broker: {error}"),
+                    })
+                }
+            }
+        }
         ClientMessage::GetNodeDefinitions => Some(ServerMessage::NodeDefinitions {
             definitions: context.state.node_registry.definitions().to_vec(),
         }),

--- a/crates/backend/src/api/websocket/routing/integrations.rs
+++ b/crates/backend/src/api/websocket/routing/integrations.rs
@@ -36,7 +36,22 @@ pub(super) async fn handle(
             } else {
                 match context.state.mqtt_broker_store.save_all(&brokers).await {
                     Ok(()) => match context.state.mqtt_service.sync_brokers(brokers.clone()) {
-                        Ok(()) => Some(ServerMessage::MqttBrokerConfigs { brokers }),
+                        Ok(()) => {
+                            if let Ok(graphs) =
+                                context.state.graph_store.list_graph_metadata().await
+                            {
+                                let statuses =
+                                    context.state.runtime_manager.runtime_statuses().await;
+                                if let Err(error) = context
+                                    .state
+                                    .mqtt_service
+                                    .sync_graph_controls(&graphs, &statuses)
+                                {
+                                    tracing::warn!(%error, "failed to sync Home Assistant graph controls after broker update");
+                                }
+                            }
+                            Some(ServerMessage::MqttBrokerConfigs { brokers })
+                        }
                         Err(error) => Some(ServerMessage::Error {
                             message: format!("Failed to apply MQTT broker configs: {error}"),
                         }),

--- a/crates/backend/src/app/startup.rs
+++ b/crates/backend/src/app/startup.rs
@@ -7,11 +7,13 @@ use std::{
 use tokio::sync::RwLock;
 
 use crate::app::state::AppState;
-use crate::messaging::event_bus::EventBus;
+use crate::messaging::event_bus::{BackendEvent, EventBus};
 use crate::node_runtime::build_node_registry;
 use crate::services::graph_store::GraphStore;
 use crate::services::image_asset_store::{ImageAssetStore, set_global_image_asset_store};
-use crate::services::mqtt::{HomeAssistantMqttService, set_global_home_assistant_mqtt_service};
+use crate::services::mqtt::{
+    HaMqttGraphControlCommand, HomeAssistantMqttService, set_global_home_assistant_mqtt_service,
+};
 use crate::services::mqtt_broker_store::MqttBrokerStore;
 use crate::services::runtime::manager::GraphRuntimeManager;
 use crate::services::wled::discovery::spawn_wled_discovery_task;
@@ -40,6 +42,14 @@ pub(crate) async fn build_app_state() -> anyhow::Result<AppState> {
     let wled_instances = Arc::new(RwLock::new(Vec::new()));
     spawn_wled_discovery_task(wled_instances.clone(), event_bus.clone());
     runtime_manager.load_persisted_state().await?;
+    sync_home_assistant_graph_controls(&graph_store, &runtime_manager, &mqtt_service).await;
+    spawn_home_assistant_graph_control_sync(
+        event_bus.clone(),
+        graph_store.clone(),
+        runtime_manager.clone(),
+        mqtt_service.clone(),
+    );
+    spawn_home_assistant_graph_control_commands(runtime_manager.clone(), mqtt_service.clone());
 
     Ok(AppState {
         connected_clients: Arc::new(AtomicUsize::new(0)),
@@ -53,6 +63,81 @@ pub(crate) async fn build_app_state() -> anyhow::Result<AppState> {
         runtime_manager,
         wled_instances,
     })
+}
+
+async fn sync_home_assistant_graph_controls(
+    graph_store: &Arc<GraphStore>,
+    runtime_manager: &Arc<GraphRuntimeManager>,
+    mqtt_service: &Arc<HomeAssistantMqttService>,
+) {
+    let graphs = match graph_store.list_graph_metadata().await {
+        Ok(graphs) => graphs,
+        Err(error) => {
+            tracing::warn!(%error, "failed to load graph metadata for Home Assistant MQTT controls");
+            return;
+        }
+    };
+    let statuses = runtime_manager.runtime_statuses().await;
+    if let Err(error) = mqtt_service.sync_graph_controls(&graphs, &statuses) {
+        tracing::warn!(%error, "failed to sync Home Assistant MQTT graph controls");
+    }
+}
+
+fn spawn_home_assistant_graph_control_sync(
+    event_bus: EventBus,
+    graph_store: Arc<GraphStore>,
+    runtime_manager: Arc<GraphRuntimeManager>,
+    mqtt_service: Arc<HomeAssistantMqttService>,
+) {
+    tokio::spawn(async move {
+        let mut events = event_bus.subscribe();
+        loop {
+            match events.recv().await {
+                Ok(BackendEvent::GraphMetadataChanged { .. })
+                | Ok(BackendEvent::RuntimeStatusesChanged { .. }) => {
+                    sync_home_assistant_graph_controls(
+                        &graph_store,
+                        &runtime_manager,
+                        &mqtt_service,
+                    )
+                    .await;
+                }
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::warn!(skipped, "Home Assistant MQTT graph control sync lagged");
+                    sync_home_assistant_graph_controls(
+                        &graph_store,
+                        &runtime_manager,
+                        &mqtt_service,
+                    )
+                    .await;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
+fn spawn_home_assistant_graph_control_commands(
+    runtime_manager: Arc<GraphRuntimeManager>,
+    mqtt_service: Arc<HomeAssistantMqttService>,
+) {
+    tokio::spawn(async move {
+        let commands = mqtt_service.graph_control_commands();
+        while let Ok(command) = commands.recv_async().await {
+            let result = match command {
+                HaMqttGraphControlCommand::Start { graph_id } => {
+                    runtime_manager.start_graph(&graph_id).await.map(|_| ())
+                }
+                HaMqttGraphControlCommand::Stop { graph_id } => {
+                    runtime_manager.stop_graph(&graph_id).await.map(|_| ())
+                }
+            };
+            if let Err(error) = result {
+                tracing::warn!(%error, "failed to apply Home Assistant MQTT graph control command");
+            }
+        }
+    });
 }
 
 /// Returns the runtime data directory used for persisted graphs, broker configs, and runtime state.

--- a/crates/backend/src/demo.rs
+++ b/crates/backend/src/demo.rs
@@ -121,6 +121,9 @@ impl DemoTransport {
                 id,
                 execution_frequency_hz,
             } => self.update_graph_execution_frequency(&id, execution_frequency_hz),
+            ClientMessage::UpdateGraphHomeAssistantBroker { id, broker_id } => {
+                self.update_graph_home_assistant_broker(&id, broker_id)
+            }
             ClientMessage::GetNodeDefinitions => Some(ServerMessage::NodeDefinitions {
                 definitions: self.node_definitions.clone(),
             }),
@@ -208,6 +211,7 @@ impl DemoTransport {
                 id: Uuid::new_v4().to_string(),
                 name: trimmed_name,
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             viewport: shared::GraphViewport::default(),
             nodes: Vec::new(),
@@ -331,6 +335,30 @@ impl DemoTransport {
             };
 
             document.metadata.execution_frequency_hz = execution_frequency_hz.max(1);
+        }
+        Some(ServerMessage::GraphMetadata {
+            documents: self.graph_metadata(),
+        })
+    }
+
+    fn update_graph_home_assistant_broker(
+        &mut self,
+        id: &str,
+        broker_id: String,
+    ) -> Option<ServerMessage> {
+        let id = id.trim();
+        {
+            let Some(document) = self
+                .graph_documents
+                .iter_mut()
+                .find(|document| document.metadata.id == id)
+            else {
+                return Some(ServerMessage::Error {
+                    message: format!("Graph document {id} was not found"),
+                });
+            };
+
+            document.metadata.home_assistant_broker_id = broker_id.trim().to_owned();
         }
         Some(ServerMessage::GraphMetadata {
             documents: self.graph_metadata(),

--- a/crates/backend/src/services/graph_store/mod.rs
+++ b/crates/backend/src/services/graph_store/mod.rs
@@ -51,6 +51,7 @@ impl GraphStore {
             id: Uuid::new_v4().to_string(),
             name,
             execution_frequency_hz: 60,
+            home_assistant_broker_id: String::new(),
         };
         {
             let _guard = self.lock.lock().await;
@@ -199,6 +200,44 @@ impl GraphStore {
             let mut document = serde_json::from_str::<GraphDocument>(&payload)
                 .with_context(|| format!("parse graph document {}", path.display()))?;
             document.metadata.execution_frequency_hz = execution_frequency_hz.max(1);
+            let payload =
+                serde_json::to_vec_pretty(&document).context("serialize graph document")?;
+            tokio::fs::write(&path, payload)
+                .await
+                .with_context(|| format!("write graph document to {}", path.display()))?;
+            true
+        };
+
+        if found {
+            self.emit_metadata_changed().await?;
+        }
+        Ok(found)
+    }
+
+    /// Updates the Home Assistant MQTT broker selected for graph-level controls.
+    ///
+    /// Returns `Ok(false)` when the graph does not exist. An empty broker id disables graph-level
+    /// Home Assistant controls for the graph.
+    pub(crate) async fn update_home_assistant_broker(
+        &self,
+        id: &str,
+        broker_id: String,
+    ) -> anyhow::Result<bool> {
+        let broker_id = broker_id.trim().to_owned();
+        let found = {
+            let _guard = self.lock.lock().await;
+            self.ensure_dir().await?;
+            let path = self.document_path(id);
+            let payload = match tokio::fs::read_to_string(&path).await {
+                Ok(payload) => payload,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+                Err(error) => {
+                    return Err(error).with_context(|| format!("read {}", path.display()));
+                }
+            };
+            let mut document = serde_json::from_str::<GraphDocument>(&payload)
+                .with_context(|| format!("parse graph document {}", path.display()))?;
+            document.metadata.home_assistant_broker_id = broker_id;
             let payload =
                 serde_json::to_vec_pretty(&document).context("serialize graph document")?;
             tokio::fs::write(&path, payload)
@@ -425,6 +464,7 @@ mod tests {
                 id: id.to_owned(),
                 name: name.to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             viewport: shared::GraphViewport::default(),
             nodes: Vec::new(),
@@ -528,6 +568,7 @@ mod tests {
                 id: "graph-1".to_owned(),
                 name: "Broken".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             viewport: shared::GraphViewport::default(),
             nodes: vec![GraphNode {

--- a/crates/backend/src/services/mqtt/mod.rs
+++ b/crates/backend/src/services/mqtt/mod.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use flume::{Receiver, Sender};
 use rumqttc::{AsyncClient, Event, LastWill, MqttOptions, Packet, QoS};
-use shared::MqttBrokerConfig;
+use shared::{GraphMetadata, GraphRuntimeMode, GraphRuntimeStatus, MqttBrokerConfig};
 use tokio::time::MissedTickBehavior;
 
 static GLOBAL_HOME_ASSISTANT_MQTT_SERVICE: OnceLock<Arc<HomeAssistantMqttService>> =
@@ -49,6 +49,18 @@ pub(crate) struct HaMqttNumberSnapshot {
     pub(crate) waiting_for_first_value: bool,
 }
 
+#[derive(Clone, PartialEq)]
+pub(crate) struct HaMqttGraphControlRegistration {
+    pub(crate) graph_id: String,
+    pub(crate) graph_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum HaMqttGraphControlCommand {
+    Start { graph_id: String },
+    Stop { graph_id: String },
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct NumberEntityKey {
     graph_id: String,
@@ -67,15 +79,25 @@ impl NumberEntityKey {
 pub(crate) struct HomeAssistantMqttService {
     configs: RwLock<HashMap<String, MqttBrokerConfig>>,
     brokers: RwLock<HashMap<String, BrokerHandle>>,
+    graph_command_tx: Sender<HaMqttGraphControlCommand>,
+    graph_command_rx: Receiver<HaMqttGraphControlCommand>,
 }
 
 impl HomeAssistantMqttService {
     /// Creates a new shared Home Assistant MQTT service.
     pub(crate) fn new() -> Arc<Self> {
+        let (graph_command_tx, graph_command_rx) = flume::unbounded();
         Arc::new(Self {
             configs: RwLock::new(HashMap::new()),
             brokers: RwLock::new(HashMap::new()),
+            graph_command_tx,
+            graph_command_rx,
         })
+    }
+
+    /// Returns a receiver for graph-level Home Assistant control commands.
+    pub(crate) fn graph_control_commands(&self) -> Receiver<HaMqttGraphControlCommand> {
+        self.graph_command_rx.clone()
     }
 
     /// Reconciles the active broker tasks with the latest configured broker list.
@@ -140,7 +162,12 @@ impl HomeAssistantMqttService {
 
             let state = Arc::new(RwLock::new(BrokerRuntimeState::default()));
             let (command_tx, command_rx) = flume::unbounded();
-            spawn_broker_task(config.clone(), state.clone(), command_rx);
+            spawn_broker_task(
+                config.clone(),
+                state.clone(),
+                command_rx,
+                self.graph_command_tx.clone(),
+            );
             brokers.insert(
                 broker_id,
                 BrokerHandle {
@@ -149,6 +176,67 @@ impl HomeAssistantMqttService {
                     command_tx,
                 },
             );
+        }
+
+        Ok(())
+    }
+
+    /// Reconciles graph-level Home Assistant controls for all active Home Assistant brokers.
+    pub(crate) fn sync_graph_controls(
+        &self,
+        graphs: &[GraphMetadata],
+        statuses: &[GraphRuntimeStatus],
+    ) -> anyhow::Result<()> {
+        let configs = self
+            .configs
+            .read()
+            .map_err(|_| anyhow::anyhow!("mqtt broker config registry lock poisoned"))?;
+        let active_broker_ids = configs
+            .iter()
+            .filter(|(_, config)| config.is_home_assistant)
+            .map(|(id, _)| id.clone())
+            .collect::<HashSet<_>>();
+        let mut controls_by_broker = active_broker_ids
+            .iter()
+            .map(|broker_id| (broker_id.clone(), Vec::new()))
+            .collect::<HashMap<_, _>>();
+
+        for graph in graphs {
+            let broker_id = graph.home_assistant_broker_id.trim();
+            if broker_id.is_empty() {
+                continue;
+            }
+            if !active_broker_ids.contains(broker_id) {
+                tracing::warn!(
+                    graph_id = %graph.id,
+                    broker_id,
+                    "graph selected a missing or non-Home Assistant MQTT broker"
+                );
+                continue;
+            }
+            controls_by_broker
+                .entry(broker_id.to_owned())
+                .or_default()
+                .push(HaMqttGraphControlRegistration {
+                    graph_id: graph.id.clone(),
+                    graph_name: graph.name.clone(),
+                });
+        }
+        drop(configs);
+
+        let brokers = self
+            .brokers
+            .read()
+            .map_err(|_| anyhow::anyhow!("mqtt broker registry lock poisoned"))?;
+        for (broker_id, handle) in brokers.iter() {
+            let controls = controls_by_broker.remove(broker_id).unwrap_or_default();
+            handle
+                .command_tx
+                .send(BrokerCommand::ReconcileGraphControls {
+                    controls,
+                    statuses: statuses.to_vec(),
+                })
+                .context("send MQTT graph controls reconciliation command")?;
         }
 
         Ok(())
@@ -263,9 +351,11 @@ struct BrokerHandle {
 #[cfg(test)]
 mod tests {
     use super::{
-        BrokerRuntimeState, HaMqttNumberRegistration, HomeAssistantMqttService, NumberEntityKey,
-        NumberEntityState, device_identifier, discovery_topic, entity_object_id, entity_unique_id,
-        graph_display_name, handle_publish, number_command_topic, number_state_topic,
+        BrokerRuntimeState, GraphControlState, HaMqttGraphControlCommand,
+        HaMqttGraphControlRegistration, HaMqttNumberRegistration, HomeAssistantMqttService,
+        NumberEntityKey, NumberEntityState, device_identifier, discovery_topic, entity_object_id,
+        entity_unique_id, graph_display_name, graph_switch_command_topic, handle_publish,
+        number_command_topic, number_state_topic,
     };
     use rumqttc::{AsyncClient, MqttOptions};
     use shared::MqttBrokerConfig;
@@ -369,10 +459,13 @@ mod tests {
     #[test]
     fn graph_display_name_falls_back_when_graph_name_is_empty() {
         let mut registration = registration();
-        assert_eq!(graph_display_name(&registration), "Graph One");
+        assert_eq!(graph_display_name(&registration.graph_name), "Graph One");
 
         registration.graph_name.clear();
-        assert_eq!(graph_display_name(&registration), "Luma Weaver Graph");
+        assert_eq!(
+            graph_display_name(&registration.graph_name),
+            "Luma Weaver Graph"
+        );
     }
 
     #[tokio::test]
@@ -421,6 +514,7 @@ mod tests {
 
         let state = Arc::new(RwLock::new(BrokerRuntimeState {
             connected: true,
+            controls: HashMap::new(),
             numbers: HashMap::from([
                 (
                     NumberEntityKey::from_registration(&first),
@@ -444,11 +538,13 @@ mod tests {
         }));
         let (client, _eventloop) =
             AsyncClient::new(MqttOptions::new("mqtt-test-client", "127.0.0.1", 1883), 10);
+        let (graph_command_tx, _graph_command_rx) = flume::unbounded();
 
         handle_publish(
             &config,
             &state,
             &client,
+            &graph_command_tx,
             number_state_topic(&config.id, &second.graph_id, &second.entity_id),
             b"7.5".to_vec(),
         )
@@ -470,12 +566,55 @@ mod tests {
             Some(7.5)
         );
     }
+
+    #[tokio::test]
+    async fn handle_publish_emits_graph_control_commands() {
+        let config = broker_config("primary", true);
+        let state = Arc::new(RwLock::new(BrokerRuntimeState {
+            connected: true,
+            controls: HashMap::from([(
+                "graph_one".to_owned(),
+                GraphControlState {
+                    registration: HaMqttGraphControlRegistration {
+                        graph_id: "graph_one".to_owned(),
+                        graph_name: "Graph One".to_owned(),
+                    },
+                },
+            )]),
+            numbers: HashMap::new(),
+        }));
+        let (client, _eventloop) =
+            AsyncClient::new(MqttOptions::new("mqtt-test-client", "127.0.0.1", 1883), 10);
+        let (graph_command_tx, graph_command_rx) = flume::unbounded();
+
+        handle_publish(
+            &config,
+            &state,
+            &client,
+            &graph_command_tx,
+            graph_switch_command_topic(&config.id, "graph_one"),
+            b"ON".to_vec(),
+        )
+        .await;
+
+        assert_eq!(
+            graph_command_rx.try_recv().expect("graph command"),
+            HaMqttGraphControlCommand::Start {
+                graph_id: "graph_one".to_owned()
+            }
+        );
+    }
 }
 
 #[derive(Default)]
 struct BrokerRuntimeState {
     connected: bool,
+    controls: HashMap<String, GraphControlState>,
     numbers: HashMap<NumberEntityKey, NumberEntityState>,
+}
+
+struct GraphControlState {
+    registration: HaMqttGraphControlRegistration,
 }
 
 struct NumberEntityState {
@@ -487,6 +626,10 @@ struct NumberEntityState {
 
 enum BrokerCommand {
     UpsertNumberEntity(HaMqttNumberRegistration),
+    ReconcileGraphControls {
+        controls: Vec<HaMqttGraphControlRegistration>,
+        statuses: Vec<GraphRuntimeStatus>,
+    },
     PublishNumberState {
         graph_id: String,
         entity_id: String,
@@ -504,6 +647,7 @@ fn spawn_broker_task(
     config: MqttBrokerConfig,
     state: Arc<RwLock<BrokerRuntimeState>>,
     command_rx: Receiver<BrokerCommand>,
+    graph_command_tx: Sender<HaMqttGraphControlCommand>,
 ) {
     tokio::spawn(async move {
         let availability_topic = broker_availability_topic(&config.id);
@@ -560,7 +704,7 @@ fn spawn_broker_task(
                                 .await;
                         }
                         Ok(Event::Incoming(Packet::Publish(publish))) => {
-                            handle_publish(&config, &state, &client, publish.topic, publish.payload.to_vec()).await;
+                            handle_publish(&config, &state, &client, &graph_command_tx, publish.topic, publish.payload.to_vec()).await;
                         }
                         Ok(_) => {}
                         Err(error) => {
@@ -608,12 +752,12 @@ async fn handle_broker_command(
                 "max": registration.max,
                 "step": registration.step,
                 "mode": "box",
-                "device": {
-                    "identifiers": [device_identifier(&registration.graph_id)],
-                    "name": graph_display_name(&registration),
-                    "manufacturer": "Luma Weaver",
-                    "model": "Graph Controls",
-                }
+                    "device": {
+                        "identifiers": [device_identifier(&registration.graph_id)],
+                        "name": graph_display_name(&registration.graph_name),
+                        "manufacturer": "Luma Weaver",
+                        "model": "Graph Controls",
+                    }
             });
             if let Err(error) = client
                 .subscribe(command_topic.clone(), QoS::AtLeastOnce)
@@ -651,6 +795,68 @@ async fn handle_broker_command(
             }
             false
         }
+        BrokerCommand::ReconcileGraphControls { controls, statuses } => {
+            let desired_ids = controls
+                .iter()
+                .map(|control| control.graph_id.clone())
+                .collect::<HashSet<_>>();
+            let removed = {
+                let mut state = match state.write() {
+                    Ok(state) => state,
+                    Err(_) => return false,
+                };
+                let removed = state
+                    .controls
+                    .keys()
+                    .filter(|graph_id| !desired_ids.contains(*graph_id))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                for graph_id in &removed {
+                    state.controls.remove(graph_id);
+                }
+                for control in &controls {
+                    state.controls.insert(
+                        control.graph_id.clone(),
+                        GraphControlState {
+                            registration: control.clone(),
+                        },
+                    );
+                }
+                removed
+            };
+
+            for graph_id in removed {
+                clear_graph_control_discovery(client, config, &graph_id).await;
+            }
+            for control in controls {
+                publish_graph_control_discovery(client, config, &control).await;
+                let status = graph_execution_status(&statuses, &control.graph_id);
+                if let Err(error) = client
+                    .publish(
+                        graph_status_state_topic(&config.id, &control.graph_id),
+                        QoS::AtLeastOnce,
+                        true,
+                        status,
+                    )
+                    .await
+                {
+                    tracing::warn!(broker_id = %config.id, %error, graph_id = %control.graph_id, "failed to publish Home Assistant graph status");
+                }
+                let switch_state = graph_switch_state(&statuses, &control.graph_id);
+                if let Err(error) = client
+                    .publish(
+                        graph_switch_state_topic(&config.id, &control.graph_id),
+                        QoS::AtLeastOnce,
+                        true,
+                        switch_state,
+                    )
+                    .await
+                {
+                    tracing::warn!(broker_id = %config.id, %error, graph_id = %control.graph_id, "failed to publish Home Assistant graph switch state");
+                }
+            }
+            false
+        }
         BrokerCommand::PublishNumberState {
             graph_id,
             entity_id,
@@ -670,7 +876,23 @@ async fn handle_broker_command(
             }
             false
         }
-        BrokerCommand::Stop => true,
+        BrokerCommand::Stop => {
+            let graph_ids = {
+                let mut state = match state.write() {
+                    Ok(state) => state,
+                    Err(_) => return true,
+                };
+                let graph_ids = state.controls.keys().cloned().collect::<Vec<_>>();
+                state.controls.clear();
+                graph_ids
+            };
+
+            for graph_id in graph_ids {
+                clear_graph_control_discovery(client, config, &graph_id).await;
+            }
+
+            true
+        }
     }
 }
 
@@ -682,9 +904,42 @@ async fn handle_publish(
     config: &MqttBrokerConfig,
     state: &Arc<RwLock<BrokerRuntimeState>>,
     client: &AsyncClient,
+    graph_command_tx: &Sender<HaMqttGraphControlCommand>,
     topic: String,
     payload: Vec<u8>,
 ) {
+    let graph_command = {
+        let state = match state.read() {
+            Ok(state) => state,
+            Err(_) => return,
+        };
+        let payload = std::str::from_utf8(&payload)
+            .ok()
+            .map(str::trim)
+            .map(str::to_ascii_uppercase);
+        state.controls.iter().find_map(|(graph_id, control)| {
+            if topic == graph_switch_command_topic(&config.id, &control.registration.graph_id) {
+                match payload.as_deref() {
+                    Some("ON") => Some(HaMqttGraphControlCommand::Start {
+                        graph_id: graph_id.clone(),
+                    }),
+                    Some("OFF") => Some(HaMqttGraphControlCommand::Stop {
+                        graph_id: graph_id.clone(),
+                    }),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        })
+    };
+    if let Some(command) = graph_command {
+        if let Err(error) = graph_command_tx.send(command) {
+            tracing::warn!(broker_id = %config.id, %error, "failed to enqueue Home Assistant graph command");
+        }
+        return;
+    }
+
     let value = match std::str::from_utf8(&payload)
         .ok()
         .map(str::trim)
@@ -749,6 +1004,99 @@ async fn handle_publish(
     }
 }
 
+async fn publish_graph_control_discovery(
+    client: &AsyncClient,
+    config: &MqttBrokerConfig,
+    registration: &HaMqttGraphControlRegistration,
+) {
+    clear_legacy_graph_button_discovery(client, config, &registration.graph_id).await;
+    let switch_command_topic = graph_switch_command_topic(&config.id, &registration.graph_id);
+    let device = serde_json::json!({
+        "identifiers": [device_identifier(&registration.graph_id)],
+        "name": graph_display_name(&registration.graph_name),
+        "manufacturer": "Luma Weaver",
+        "model": "Graph Controls",
+    });
+    let switch_payload = serde_json::json!({
+        "name": "Execution",
+        "unique_id": graph_control_unique_id(&config.id, &registration.graph_id, "execution"),
+        "object_id": graph_control_object_id(&registration.graph_id, "execution"),
+        "state_topic": graph_switch_state_topic(&config.id, &registration.graph_id),
+        "command_topic": switch_command_topic,
+        "availability_topic": broker_availability_topic(&config.id),
+        "payload_on": "ON",
+        "payload_off": "OFF",
+        "state_on": "ON",
+        "state_off": "OFF",
+        "icon": "mdi:play-pause",
+        "device": device.clone(),
+    });
+    let status_payload = serde_json::json!({
+        "name": "Execution Status",
+        "unique_id": graph_control_unique_id(&config.id, &registration.graph_id, "status"),
+        "object_id": graph_control_object_id(&registration.graph_id, "status"),
+        "state_topic": graph_status_state_topic(&config.id, &registration.graph_id),
+        "availability_topic": broker_availability_topic(&config.id),
+        "icon": "mdi:play-circle-outline",
+        "device": device,
+    });
+
+    if let Err(error) = client
+        .subscribe(switch_command_topic.clone(), QoS::AtLeastOnce)
+        .await
+    {
+        tracing::warn!(broker_id = %config.id, %error, topic = %switch_command_topic, "failed to subscribe to Home Assistant graph command topic");
+    }
+
+    let discovery_payloads = [
+        (
+            graph_control_discovery_topic(config, &registration.graph_id, "switch", "execution"),
+            switch_payload,
+        ),
+        (
+            graph_control_discovery_topic(config, &registration.graph_id, "sensor", "status"),
+            status_payload,
+        ),
+    ];
+    for (topic, payload) in discovery_payloads {
+        if let Err(error) = client
+            .publish(topic, QoS::AtLeastOnce, true, payload.to_string())
+            .await
+        {
+            tracing::warn!(broker_id = %config.id, %error, graph_id = %registration.graph_id, "failed to publish Home Assistant graph discovery payload");
+        }
+    }
+}
+
+async fn clear_graph_control_discovery(
+    client: &AsyncClient,
+    config: &MqttBrokerConfig,
+    graph_id: &str,
+) {
+    let switch_command_topic = graph_switch_command_topic(&config.id, graph_id);
+    let _ = client.unsubscribe(switch_command_topic).await;
+    for (domain, entity_id) in [("switch", "execution"), ("sensor", "status")] {
+        let topic = graph_control_discovery_topic(config, graph_id, domain, entity_id);
+        if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, "").await {
+            tracing::warn!(broker_id = %config.id, %error, graph_id, "failed to clear Home Assistant graph discovery payload");
+        }
+    }
+    clear_legacy_graph_button_discovery(client, config, graph_id).await;
+}
+
+async fn clear_legacy_graph_button_discovery(
+    client: &AsyncClient,
+    config: &MqttBrokerConfig,
+    graph_id: &str,
+) {
+    for (domain, entity_id) in [("button", "start"), ("button", "stop")] {
+        let topic = graph_control_discovery_topic(config, graph_id, domain, entity_id);
+        if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, "").await {
+            tracing::warn!(broker_id = %config.id, %error, graph_id, "failed to clear legacy Home Assistant graph button discovery payload");
+        }
+    }
+}
+
 /// Updates the cached connection state for a broker runtime.
 fn update_connected(
     state: &Arc<RwLock<BrokerRuntimeState>>,
@@ -790,6 +1138,33 @@ fn number_command_topic(broker_id: &str, graph_id: &str, entity_id: &str) -> Str
     )
 }
 
+/// Returns the MQTT command topic for a graph execution switch.
+fn graph_switch_command_topic(broker_id: &str, graph_id: &str) -> String {
+    format!(
+        "luma_weaver/{}/graph/{}/execution/set",
+        sanitize_identifier(broker_id),
+        sanitize_identifier(graph_id)
+    )
+}
+
+/// Returns the MQTT state topic for a graph execution switch.
+fn graph_switch_state_topic(broker_id: &str, graph_id: &str) -> String {
+    format!(
+        "luma_weaver/{}/graph/{}/execution/state",
+        sanitize_identifier(broker_id),
+        sanitize_identifier(graph_id)
+    )
+}
+
+/// Returns the MQTT state topic for a graph execution status sensor.
+fn graph_status_state_topic(broker_id: &str, graph_id: &str) -> String {
+    format!(
+        "luma_weaver/{}/graph/{}/status",
+        sanitize_identifier(broker_id),
+        sanitize_identifier(graph_id)
+    )
+}
+
 /// Returns the MQTT availability topic for a broker connection.
 fn broker_availability_topic(broker_id: &str) -> String {
     format!(
@@ -822,13 +1197,72 @@ fn entity_unique_id(broker_id: &str, graph_id: &str, entity_id: &str) -> String 
     )
 }
 
+/// Returns the Home Assistant discovery topic for a graph control entity.
+fn graph_control_discovery_topic(
+    config: &MqttBrokerConfig,
+    graph_id: &str,
+    domain: &str,
+    entity_id: &str,
+) -> String {
+    format!(
+        "{}/{}/luma_weaver/{}/config",
+        config.discovery_prefix.trim().trim_end_matches('/'),
+        domain,
+        graph_control_object_id(graph_id, entity_id)
+    )
+}
+
+/// Returns the stable object ID for a graph control entity.
+fn graph_control_object_id(graph_id: &str, entity_id: &str) -> String {
+    format!(
+        "{}_{}",
+        sanitize_identifier(graph_id),
+        sanitize_identifier(entity_id)
+    )
+}
+
+/// Returns the stable Home Assistant unique ID for a graph control entity.
+fn graph_control_unique_id(broker_id: &str, graph_id: &str, entity_id: &str) -> String {
+    format!(
+        "luma_weaver_{}_{}_{}",
+        sanitize_identifier(broker_id),
+        sanitize_identifier(graph_id),
+        sanitize_identifier(entity_id)
+    )
+}
+
 /// Returns the display name Home Assistant should show for the graph-backed device.
-fn graph_display_name(registration: &HaMqttNumberRegistration) -> String {
-    let graph_name = registration.graph_name.trim();
+fn graph_display_name(graph_name: &str) -> String {
+    let graph_name = graph_name.trim();
     if graph_name.is_empty() {
         "Luma Weaver Graph".to_owned()
     } else {
         graph_name.to_owned()
+    }
+}
+
+/// Returns the execution status string exposed to Home Assistant.
+fn graph_execution_status(statuses: &[GraphRuntimeStatus], graph_id: &str) -> &'static str {
+    match statuses
+        .iter()
+        .find(|status| status.graph_id == graph_id)
+        .map(|status| status.mode)
+    {
+        Some(GraphRuntimeMode::Running) => "running",
+        Some(GraphRuntimeMode::Paused) => "paused",
+        None => "stopped",
+    }
+}
+
+/// Returns the binary switch state exposed to Home Assistant.
+fn graph_switch_state(statuses: &[GraphRuntimeStatus], graph_id: &str) -> &'static str {
+    match statuses
+        .iter()
+        .find(|status| status.graph_id == graph_id)
+        .map(|status| status.mode)
+    {
+        Some(GraphRuntimeMode::Running) => "ON",
+        Some(GraphRuntimeMode::Paused) | None => "OFF",
     }
 }
 

--- a/crates/backend/src/services/runtime/compiler.rs
+++ b/crates/backend/src/services/runtime/compiler.rs
@@ -330,6 +330,7 @@ mod tests {
                     id: format!("audit-{}", definition.id),
                     name: definition.display_name.clone(),
                     execution_frequency_hz: 60,
+                    home_assistant_broker_id: String::new(),
                 },
                 viewport: shared::GraphViewport::default(),
                 nodes: vec![GraphNode {

--- a/crates/frontend/src/app/clipboard.rs
+++ b/crates/frontend/src/app/clipboard.rs
@@ -245,6 +245,7 @@ mod tests {
                 id: "graph-b".to_owned(),
                 name: "Graph B".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             ..GraphDocument::default()
         });

--- a/crates/frontend/src/app/graph_actions.rs
+++ b/crates/frontend/src/app/graph_actions.rs
@@ -68,6 +68,41 @@ impl FrontendApp {
         });
     }
 
+    /// Updates the Home Assistant broker used for graph-level control entities.
+    pub(crate) fn update_graph_home_assistant_broker(
+        &mut self,
+        graph_id: String,
+        broker_id: String,
+    ) {
+        let broker_id = broker_id.trim().to_owned();
+
+        if let Some(graph) = self
+            .graphs
+            .graph_documents
+            .iter_mut()
+            .find(|graph| graph.id == graph_id)
+        {
+            graph.home_assistant_broker_id = broker_id.clone();
+        }
+
+        if self
+            .graphs
+            .loaded_graph_document
+            .as_ref()
+            .map(|document| document.metadata.id.as_str())
+            == Some(graph_id.as_str())
+        {
+            if let Some(document) = self.graphs.loaded_graph_document.as_mut() {
+                document.metadata.home_assistant_broker_id = broker_id.clone();
+            }
+        }
+
+        self.send(ClientMessage::UpdateGraphHomeAssistantBroker {
+            id: graph_id,
+            broker_id,
+        });
+    }
+
     /// Updates the locally cached graph name and sends the rename request to the backend.
     ///
     /// Empty names are rejected immediately so the user gets fast feedback without waiting for the

--- a/crates/frontend/src/app/messaging.rs
+++ b/crates/frontend/src/app/messaging.rs
@@ -62,6 +62,9 @@ fn client_message_kind(message: &ClientMessage) -> &'static str {
         ClientMessage::UpdateGraphName { .. } => "update_graph_name",
         ClientMessage::ImportGraphDocument { .. } => "import_graph_document",
         ClientMessage::UpdateGraphExecutionFrequency { .. } => "update_graph_execution_frequency",
+        ClientMessage::UpdateGraphHomeAssistantBroker { .. } => {
+            "update_graph_home_assistant_broker"
+        }
         ClientMessage::GetNodeDefinitions => "get_node_definitions",
         ClientMessage::GetGraphMetadata => "get_graph_metadata",
         ClientMessage::StartGraph { .. } => "start_graph",

--- a/crates/frontend/src/app/server_state.rs
+++ b/crates/frontend/src/app/server_state.rs
@@ -345,6 +345,7 @@ mod tests {
                 id: "graph-a".to_owned(),
                 name: "Graph A".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             nodes: vec![GraphNode {
                 id: "node-1".to_owned(),

--- a/crates/frontend/src/dashboard_view.rs
+++ b/crates/frontend/src/dashboard_view.rs
@@ -102,6 +102,13 @@ pub(crate) fn render(ctx: &egui::Context, ui: &mut egui::Ui, app: &mut FrontendA
         });
     } else {
         let graphs = app.graphs.graph_documents.clone();
+        let home_assistant_brokers = app
+            .graphs
+            .mqtt_broker_configs
+            .iter()
+            .filter(|broker| broker.is_home_assistant)
+            .cloned()
+            .collect::<Vec<_>>();
         let mut open_graph: Option<String> = None;
         let mut delete_graph: Option<String> = None;
         let mut rename_graph: Option<(String, String)> = None;
@@ -200,6 +207,35 @@ pub(crate) fn render(ctx: &egui::Context, ui: &mut egui::Ui, app: &mut FrontendA
                             app.update_graph_execution_frequency(
                                 graph_id.clone(),
                                 execution_frequency_hz,
+                            );
+                        }
+                        ui.add_space(8.0);
+                        ui.label(RichText::new("HA broker").color(Color32::from_gray(150)));
+                        let mut selected_broker_id = graph.home_assistant_broker_id.clone();
+                        egui::ComboBox::from_id_salt(format!("graph_ha_broker_{graph_id}"))
+                            .width(190.0)
+                            .selected_text(home_assistant_broker_label(
+                                &selected_broker_id,
+                                &home_assistant_brokers,
+                            ))
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(
+                                    &mut selected_broker_id,
+                                    String::new(),
+                                    "Disabled",
+                                );
+                                for broker in &home_assistant_brokers {
+                                    ui.selectable_value(
+                                        &mut selected_broker_id,
+                                        broker.id.clone(),
+                                        broker.display_name.clone(),
+                                    );
+                                }
+                            });
+                        if selected_broker_id != graph.home_assistant_broker_id {
+                            app.update_graph_home_assistant_broker(
+                                graph_id.clone(),
+                                selected_broker_id,
                             );
                         }
                     });
@@ -462,6 +498,20 @@ fn runtime_badge(ui: &mut egui::Ui, mode: Option<GraphRuntimeMode>) {
         .show(ui, |ui| {
             ui.label(RichText::new(label).color(color).strong());
         });
+}
+
+/// Returns the display label for a graph-level Home Assistant broker selection.
+fn home_assistant_broker_label(broker_id: &str, brokers: &[MqttBrokerConfig]) -> String {
+    let broker_id = broker_id.trim();
+    if broker_id.is_empty() {
+        return "Disabled".to_owned();
+    }
+
+    brokers
+        .iter()
+        .find(|broker| broker.id == broker_id)
+        .map(|broker| broker.display_name.clone())
+        .unwrap_or_else(|| format!("{broker_id} (unavailable)"))
 }
 
 /// Returns the most severe diagnostic summary for a graph, breaking ties by active count.

--- a/crates/frontend/src/editor_view/model.rs
+++ b/crates/frontend/src/editor_view/model.rs
@@ -878,6 +878,7 @@ mod tests {
                 id: "graph-a".to_owned(),
                 name: "Graph A".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             viewport: shared::GraphViewport::default(),
             nodes: vec![
@@ -926,6 +927,7 @@ mod tests {
                 id: "graph-b".to_owned(),
                 name: "Graph B".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             ..GraphDocument::default()
         };

--- a/crates/frontend/src/transport.rs
+++ b/crates/frontend/src/transport.rs
@@ -252,6 +252,9 @@ mod websocket {
             ClientMessage::UpdateGraphExecutionFrequency { .. } => {
                 "update_graph_execution_frequency"
             }
+            ClientMessage::UpdateGraphHomeAssistantBroker { .. } => {
+                "update_graph_home_assistant_broker"
+            }
             ClientMessage::GetNodeDefinitions => "get_node_definitions",
             ClientMessage::GetGraphMetadata => "get_graph_metadata",
             ClientMessage::StartGraph { .. } => "start_graph",

--- a/crates/shared/src/graph/document.rs
+++ b/crates/shared/src/graph/document.rs
@@ -9,6 +9,8 @@ pub struct GraphMetadata {
     pub name: String,
     #[serde(default = "default_execution_frequency_hz")]
     pub execution_frequency_hz: u32,
+    #[serde(default)]
+    pub home_assistant_broker_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -31,6 +33,7 @@ impl Default for GraphDocument {
                 id: String::new(),
                 name: String::new(),
                 execution_frequency_hz: default_execution_frequency_hz(),
+                home_assistant_broker_id: String::new(),
             },
             viewport: GraphViewport::default(),
             nodes: Vec::new(),

--- a/crates/shared/src/protocol.rs
+++ b/crates/shared/src/protocol.rs
@@ -86,6 +86,10 @@ pub enum ClientMessage {
         id: String,
         execution_frequency_hz: u32,
     },
+    UpdateGraphHomeAssistantBroker {
+        id: String,
+        broker_id: String,
+    },
     GetNodeDefinitions,
     GetGraphMetadata,
     StartGraph {

--- a/crates/shared/src/validation.rs
+++ b/crates/shared/src/validation.rs
@@ -245,6 +245,7 @@ mod tests {
                 id: "graph".to_owned(),
                 name: "Graph".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             viewport: crate::GraphViewport::default(),
             nodes: vec![
@@ -283,6 +284,7 @@ mod tests {
                 id: "graph".to_owned(),
                 name: "Graph".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             viewport: crate::GraphViewport::default(),
             nodes: vec![
@@ -339,6 +341,7 @@ mod tests {
                 id: "graph".to_owned(),
                 name: "Graph".to_owned(),
                 execution_frequency_hz: 60,
+                home_assistant_broker_id: String::new(),
             },
             viewport: crate::GraphViewport::default(),
             nodes: vec![

--- a/docs/developer/backend-objects.md
+++ b/docs/developer/backend-objects.md
@@ -166,6 +166,7 @@ Main responsibilities:
 
 - keep the configured broker set in memory
 - spawn and stop per-broker runtime tasks
+- expose graph-level execution switch and execution status entities
 - expose graph-backed MQTT number entities
 - publish discovery payloads
 - mirror command/state messages

--- a/docs/user/integrations.md
+++ b/docs/user/integrations.md
@@ -16,7 +16,7 @@ Because discovery and device communication happen in the backend, WLED features 
 
 ## Home Assistant MQTT
 
-Luma Weaver can expose values through Home Assistant MQTT `number` entities.
+Luma Weaver can expose graph controls and graph values through Home Assistant MQTT entities.
 
 The backend is responsible for:
 
@@ -27,6 +27,13 @@ The backend is responsible for:
 - synchronization for registered graph nodes
 
 Reusable broker configs can be marked as Home Assistant brokers in the UI. Only those marked brokers are offered to Home Assistant nodes.
+
+On the graph overview page, each graph can select one configured Home Assistant broker. Selecting a broker creates graph-level Home Assistant entities for that graph:
+
+- an `Execution` switch that starts the graph when turned on and stops it when turned off
+- an `Execution Status` sensor with `running`, `paused`, or `stopped`
+
+Home Assistant MQTT Number nodes still create their own per-graph `number` entities through the broker selected on the node.
 
 ## Demo Mode Limitations
 


### PR DESCRIPTION
## Summary

- add a per-graph Home Assistant broker selection persisted in graph metadata
- publish Home Assistant MQTT discovery for graph execution switch and execution status entities
- route Home Assistant MQTT switch commands into graph start/stop runtime actions
- keep graph-control entities synced when graph metadata, runtime status, or broker config changes
- document graph-level Home Assistant controls alongside existing MQTT number entities

## Why

Home Assistant users should be able to start, stop, and inspect Luma Weaver graph execution from Home Assistant without adding a dedicated node to the graph.

## Testing

- `cargo test -p shared -p backend --locked`

## Compatibility Notes

Existing graph documents remain compatible because `home_assistant_broker_id` defaults to an empty string when absent. Empty broker selection disables graph-level Home Assistant controls. The broker shutdown path clears retained graph-control discovery payloads to avoid stale Home Assistant entities when a broker is removed or unmarked.